### PR TITLE
Bugfix: avoid empty solvers[].http01.ingress

### DIFF
--- a/katalog/cert-manager/cert-manager-controller/issuer.yml
+++ b/katalog/cert-manager/cert-manager-controller/issuer.yml
@@ -9,7 +9,9 @@ spec:
       name: letsencrypt-staging
     server: https://acme-staging-v02.api.letsencrypt.org/directory
     solvers:
-    - http01: {}
+    - http01:
+        ingress:
+          class: nginx
 ---
 apiVersion: certmanager.k8s.io/v1alpha1
 kind: ClusterIssuer
@@ -22,4 +24,6 @@ spec:
       name: letsencrypt-production
     server: https://acme-v02.api.letsencrypt.org/directory
     solvers:
-    - http01: {}
+    - http01:
+        ingress:
+          class: nginx


### PR DESCRIPTION
Specify solvers[].http01.ingress stanza in order to avoid error msgs
like the one below which appeared during internal testing of the
cert-manager upgrades:

E0911 09:34:30.658130       1 sync.go:265]
cert-manager/controller/challenges/finalizer "msg"="error cleaning up
challenge" "error"="challenge's 'solver' field is specified but no
HTTP01 ingress config provided. Ensure solvers[].http01.ingress is
specified on your issuer resource" "dnsName"="test-cm-1.sighup.io"
"resource_kind"="Challenge"
"resource_name"="test-letsencrypt-prod-tls-1237449791-0"
"resource_namespace"="ingress-nginx" "type"="http-01"