### PR TITLE
Add 'networking.k8s.io' apiGroup in ingress roles

### DIFF
--- a/katalog/nginx/rbac.yml
+++ b/katalog/nginx/rbac.yml
@@ -34,7 +34,15 @@ rules:
       - list
       - watch
   - apiGroups:
+      - ""
+    resources:
+      - events
+    verbs:
+      - create
+      - patch
+  - apiGroups:
       - "extensions"
+      - "networking.k8s.io"
     resources:
       - ingresses
     verbs:
@@ -42,14 +50,8 @@ rules:
       - list
       - watch
   - apiGroups:
-      - ""
-    resources:
-        - events
-    verbs:
-        - create
-        - patch
-  - apiGroups:
       - "extensions"
+      - "networking.k8s.io"
     resources:
       - ingresses/status
     verbs:


### PR DESCRIPTION
Current fury-kubernetes-ingress release is missing networking.k8s.io
apiGroup in ingress-related resource in RBAC role. As a result this is
preventing the pods from starting up. This commit is adding the missing
apiGroup.
Together with this I've re-organized the list in order to put the
ingress-related resources close to each-other - as it's in the ingress
upstream:
https://github.com/kubernetes/ingress-nginx/blob/master/deploy/static/mandatory.yaml

The fix has been tested on a fresh GKE 1.14 cluster.