### PR TITLE
Update nginx ingress controller version

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,6 @@ from various issuing sources.. Version: **v0.9.0**
 panel where you can see your running applications and access them
 on Kubernetes. Version: **1.0.22**.
 - [nginx](katalog/nginx): The NGINX Ingress Controller for Kubernetes
-provides delivery services for Kubernetes applications. Version: **0.25.1**
+provides delivery services for Kubernetes applications. Version: **0.26.1**
 - [dual-nginx](katalog/dual-nginx): It deploys two identical nginx ingress controllers
-but with two different scopes: public/external and private/internal. Version: **0.25.1**
+but with two different scopes: public/external and private/internal. Version: **0.26.1**

--- a/katalog/dual-nginx/README.md
+++ b/katalog/dual-nginx/README.md
@@ -10,7 +10,7 @@ Ingress Nginx is an Ingress Controller for [NGINX](https://nginx.org) webserver 
 
 ## Image repository and tag
 
-* Nginx IC image: `quay.io/kubernetes-ingress-controller/nginx-ingress-controller:0.25.1`
+* Nginx IC image: `quay.io/kubernetes-ingress-controller/nginx-ingress-controller:0.26.1`
 * Nginx IC repo: https://github.com/kubernetes/ingress-nginx
 
 

--- a/katalog/dual-nginx/deployment-external.yml
+++ b/katalog/dual-nginx/deployment-external.yml
@@ -16,7 +16,7 @@ spec:
       serviceAccountName: nginx-ingress-serviceaccount
       containers:
         - name: nginx-ingress-controller
-          image: quay.io/kubernetes-ingress-controller/nginx-ingress-controller:0.25.1
+          image: quay.io/kubernetes-ingress-controller/nginx-ingress-controller:0.26.1
           args:
             - /nginx-ingress-controller
             - --configmap=$(POD_NAMESPACE)/nginx-external

--- a/katalog/dual-nginx/deployment-internal.yml
+++ b/katalog/dual-nginx/deployment-internal.yml
@@ -16,7 +16,7 @@ spec:
       serviceAccountName: nginx-ingress-serviceaccount
       containers:
         - name: nginx-ingress-controller
-          image: quay.io/kubernetes-ingress-controller/nginx-ingress-controller:0.25.1
+          image: quay.io/kubernetes-ingress-controller/nginx-ingress-controller:0.26.1
           args:
             - /nginx-ingress-controller
             - --configmap=$(POD_NAMESPACE)/nginx-internal

--- a/katalog/nginx/README.md
+++ b/katalog/nginx/README.md
@@ -11,7 +11,7 @@ Ingress Nginx is an Ingress Controller for [NGINX](https://nginx.org) webserver 
 
 ## Image repository and tag
 
-* Ingress Nginx image: `quay.io/kubernetes-ingress-controller/nginx-ingress-controller:0.25.1`
+* Ingress Nginx image: `quay.io/kubernetes-ingress-controller/nginx-ingress-controller:0.26.1`
 * Ingress Nginx repo: https://github.com/kubernetes/ingress-nginx
 
 

--- a/katalog/nginx/deployment.yml
+++ b/katalog/nginx/deployment.yml
@@ -14,7 +14,7 @@ spec:
       serviceAccountName: nginx-ingress-serviceaccount
       containers:
         - name: nginx-ingress-controller
-          image: quay.io/kubernetes-ingress-controller/nginx-ingress-controller:0.25.1
+          image: quay.io/kubernetes-ingress-controller/nginx-ingress-controller:0.26.1
           args:
             - /nginx-ingress-controller
             - --configmap=$(POD_NAMESPACE)/nginx-configuration


### PR DESCRIPTION
Hi team.

Actually, we are providing nginx-ingress-controller version 0.25.1. 

Seems like the sticky session feature is partially-broken and it is fixed in version 0.26.0: [**Merged PR**](https://github.com/kubernetes/ingress-nginx/pull/4478). 

As it is a newer version that applies a hotfix to 0.26.0 version, I suggest to update our package to provide `nginx-ingress-controller` version **0.26.1** (actual latest)

Thanks!