### PR TITLE
Update forecastle to v1.0.34

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ add-on to automate the management and issuance of TLS certificates
 from various issuing sources.. Version: **v0.9.0**
 - [forecastle](katalog/forecastle): Forecastle gives you access to a control
 panel where you can see your running applications and access them
-on Kubernetes. Version: **1.0.22**.
+on Kubernetes. Version: **1.0.34**.
 - [nginx](katalog/nginx): The NGINX Ingress Controller for Kubernetes
 provides delivery services for Kubernetes applications. Version: **0.26.1**
 - [dual-nginx](katalog/dual-nginx): It deploys two identical nginx ingress controllers

--- a/katalog/forecastle/deploy.yml
+++ b/katalog/forecastle/deploy.yml
@@ -17,7 +17,7 @@ spec:
       serviceAccountName: forecastle
       containers:
         - name: forecastle
-          image: 'stakater/forecastle:v1.0.22'
+          image: stakater/forecastle:v1.0.34
           env:
           - name: KUBERNETES_NAMESPACE
             valueFrom:

--- a/katalog/tests/tests.bats
+++ b/katalog/tests/tests.bats
@@ -30,6 +30,10 @@ wait_for_settlement (){
   apply katalog/cert-manager
 }
 
+@test "testing forecastle apply" {
+  apply katalog/forecastle
+}
+
 @test "wait for apply to settle and dump state to dump.json" {
   wait_for_settlement 24
 }


### PR DESCRIPTION
The aim of this PR is to update forecastle to v1.0.34, this way we can use the `forecastle.stakater.com/url` to overwrite the URL inferred from the ingress to allow, for example, for non-standard ports.

I left out the new CRD on purpose as I don't think it could be of any use to us.