### PR TITLE
Added documented step for deploy certManager accordingly with nginx flavour

### DIFF
--- a/katalog/cert-manager/README.md
+++ b/katalog/cert-manager/README.md
@@ -34,18 +34,18 @@ So before proceed to the build and apply, you should provide a patchesJson6902 l
 
 ```yml
 patchesJson6902:
-  - target:
-      group: certmanager.k8s.io
-      version: v1alpha1
-      kind: ClusterIssuer
-      name: letsencrypt-staging
-    path: patches/dual-nginx.yml
-  - target:
-      group: certmanager.k8s.io
-      version: v1alpha1
-      kind: ClusterIssuer
-      name: letsencrypt-prod
-    path: patches/dual-nginx.yml
+    - target:
+          group: certmanager.k8s.io
+          version: v1alpha1
+          kind: ClusterIssuer
+          name: letsencrypt-staging
+      path: patches/dual-nginx.yml
+    - target:
+          group: certmanager.k8s.io
+          version: v1alpha1
+          kind: ClusterIssuer
+          name: letsencrypt-prod
+      path: patches/dual-nginx.yml
 ```
 
 and under the `patches/dual-nginx.yml`:
@@ -54,7 +54,7 @@ and under the `patches/dual-nginx.yml`:
 ---
 - op: "replace"
   path: "/spec/acme/solvers/0/http01/ingress/class"
-  value: "dual-nginx"
+  value: "external"
 ```
 
 this is only needed when you'll use the the `dual-nginx` because the default is the `nginx` single node

--- a/katalog/cert-manager/README.md
+++ b/katalog/cert-manager/README.md
@@ -1,4 +1,5 @@
 # cert-manager
+
 cert-manager is an automation tool for management and issuence of TLS
 certificates from various issuing resource in a Kubernetes native way. It
 ensures that certificates are valid and attempts to renew them before expiry.
@@ -6,29 +7,66 @@ ensures that certificates are valid and attempts to renew them before expiry.
 This package deploys cert-manager to be used with [Let's
 Encrypt](https://letsencrypt.org/) Certificate Authority.
 
-
 ## Requirements
-- Kubernetes >= `1.10.0`
-- Kustomize >= `v1`
-- [nginx-ingress]()
 
+-   Kubernetes >= `1.10.0`
+-   Kustomize >= `v1`
+-   [nginx-ingress]()
 
 ## Image repository and tag
-* Cert Manager image: `quay.io/jetstack/cert-manager-controller:v0.9.0`
-* Cert Manager repo: https://github.com/jetstack/cert-manager
-* Cert Manager documentation: https://docs.cert-manager.io/en/release-0.9/index.html
 
+-   Cert Manager image: `quay.io/jetstack/cert-manager-controller:v0.9.0`
+-   Cert Manager repo: https://github.com/jetstack/cert-manager
+-   Cert Manager documentation: https://docs.cert-manager.io/en/release-0.9/index.html
 
 ## Configuration
+
 Fury distribution cert-manager is deployed with following configuration:
-- Default issuer kind is ClusterIssuer
-- Default issuer is letsencrypt
+
+-   Default issuer kind is ClusterIssuer
+-   Default issuer is letsencrypt
 
 ## Deployment
-You can deploy Cert Manager by running following command in the root of the project:
+
+The deployment is the following, but keep in mind that, depending of `nginx` or `dual-nginx` you need to specify the class name accordingly.
+To do that you need to patch the ClusterIssuer resource in order to keep it synced with your specific deployment.
+So before proceed to the build and apply, you should provide a patchesJson6902 like the following:
+
+```yml
+patchesJson6902:
+  - target:
+      group: certmanager.k8s.io
+      version: v1alpha1
+      kind: ClusterIssuer
+      name: letsencrypt-staging
+    path: patches/dual-nginx.yml
+  - target:
+      group: certmanager.k8s.io
+      version: v1alpha1
+      kind: ClusterIssuer
+      name: letsencrypt-prod
+    path: patches/dual-nginx.yml
+```
+
+and under the `patches/dual-nginx.yml`:
+
+```yml
+---
+- op: "replace"
+  path: "/spec/acme/solvers/0/http01/ingress/class"
+  value: "dual-nginx"
+```
+
+this is only needed when you'll use the the `dual-nginx` because the default is the `nginx` single node
+
+Once do that, you just need to hit:
+
 ```shell
 $ kustomize build | kubectl apply -f -
+
+
 ```
 
 ## License
+
 For license details please see [LICENSE](https://sighup.io/fury/license).


### PR DESCRIPTION
The following PR just include a few documented step to be followed in order to deploy certmanager, depending on the nginx flavour you've selected (single or dual-nginx). 
This is just the first step, that further need to be ported also to the ufficial docs as well.
Let me know!