### PR TITLE
Update Forecastle to v1.0.42

### DIFF
--- a/katalog/forecastle/README.md
+++ b/katalog/forecastle/README.md
@@ -1,1 +1,39 @@
 # Forecastle
+[Forecastle](https://github.com/stakater/Forecastle) provides an handy dashboard
+to show all the applications running on Kubernetes exposed through an Ingress.
+
+## Requirements
+- Kubernetes >= `1.14.0`
+- Kustomize >= `v3`
+
+
+## Image repository and tag
+- Forecastle image: `docker.io/stakater/forecastle:v1.0.42`
+- Forecastl repo: https://github.com/stakater/Forecastle
+
+## Configuration
+Forecastle is deployed with the following configuration:
+- watch every namespace for ingresses
+- CRD support disabled
+- unprivileged Pod
+- hardened RBAC
+- constrained resources
+
+## Deployment
+Forecastle can be deployed by running the following command in the root of the
+project:
+```shell
+kustomize build katalog/forecastl | kubectl apply -f -
+```
+
+### Usage
+Once deployed, to have your ingress show up in the dashboard provided by
+Forecastle:
+```shell
+kubectl annotate ingress YOUR_INGRESS "forecastle.stakater.com/expose=true" --overwrite
+```
+
+## Important notes
+The `kubernetes.io/ingress.class` annotation is required by Forecastle to have
+the ingress displayed in the dashboard, therefore you need to add such annotation to
+all your ingresses even when using a single ingress controller.

--- a/katalog/forecastle/config.yaml
+++ b/katalog/forecastle/config.yaml
@@ -1,1 +1,3 @@
-namespaces: null
+namespaceSelector:
+  any: true
+crdEnabled: false

--- a/katalog/forecastle/deploy.yml
+++ b/katalog/forecastle/deploy.yml
@@ -31,6 +31,16 @@ spec:
             httpGet:
               path: /
               port: http
+          securityContext:
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            privileged: false
+            runAsNonRoot: true
+            runAsGroup: 3000
+            runAsUser: 1000
+            capabilities:
+              drop:
+              - ALL
           ports:
           - name: http
             protocol: TCP

--- a/katalog/forecastle/deploy.yml
+++ b/katalog/forecastle/deploy.yml
@@ -17,7 +17,7 @@ spec:
       serviceAccountName: forecastle
       containers:
         - name: forecastle
-          image: stakater/forecastle:v1.0.34
+          image: stakater/forecastle
           env:
           - name: KUBERNETES_NAMESPACE
             valueFrom:

--- a/katalog/forecastle/kustomization.yaml
+++ b/katalog/forecastle/kustomization.yaml
@@ -8,6 +8,10 @@ resources:
   - deploy.yml
   - rbac.yml
 
+images:
+  - name: stakater/forecastle
+    newTag: v1.0.42
+
 configMapGenerator:
   - name: forecastle-config
     files:

--- a/katalog/forecastle/rbac.yml
+++ b/katalog/forecastle/rbac.yml
@@ -12,9 +12,14 @@ metadata:
   labels:
     app: forecastle
 rules:
-  - apiGroups: ['', 'extensions']
-    resources: ['ingresses']
-    verbs: ['get', 'list']
+  - apiGroups:
+      - extensions
+      - networking.k8s.io
+    resources:
+      - ingresses
+    verbs:
+      - get
+      - list
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding


### PR DESCRIPTION
The aim of this PR is to update Forecastle to v1.0.42.

Summary of changes:
  - updated Forecastle to v1.0.42
  - added `securityContext` to Forecastle container
  - added README

No particular care has to be taken to update from Fury's current version (v1.0.34) to v1.0.42.

Please note that I've disabled Forecastle CRD support (see [here](https://github.com/stakater/Forecastle#forecastleapp-crd)) since it seemed a little overkill to me.