### PR TITLE
Update ingress-nginx to 0.30.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,9 +14,9 @@ from various issuing sources.. Version: **v0.9.0**
 panel where you can see your running applications and access them
 on Kubernetes. Version: **1.0.34**.
 - [nginx](katalog/nginx): The NGINX Ingress Controller for Kubernetes
-provides delivery services for Kubernetes applications. Version: **0.26.1**
+provides delivery services for Kubernetes applications. Version: **0.30.0**
 - [dual-nginx](katalog/dual-nginx): It deploys two identical nginx ingress controllers
-but with two different scopes: public/external and private/internal. Version: **0.26.1**
+but with two different scopes: public/external and private/internal. Version: **0.30.0**
 - [nginx-ldap-auth](katalog/nginx-ldap-auth): Use this in order to provide a ingress authentication over LDAP for
 Kubernetes. Version: **1.0.6**
 

--- a/katalog/dual-nginx/README.md
+++ b/katalog/dual-nginx/README.md
@@ -1,7 +1,7 @@
 # Ingress Dual Nginx
 
-Ingress Nginx is an Ingress Controller for [NGINX](https://nginx.org) webserver and reverse proxy, it manages Nginx in 
-a Kubernetes native manner. This package deploys 2 Nginx Controllers, one `external` to serve public traffic, 
+Ingress Nginx is an Ingress Controller for [NGINX](https://nginx.org) webserver and reverse proxy, it manages Nginx in
+a Kubernetes native manner. This package deploys 2 Nginx Controllers, one `external` to serve public traffic,
 one `internal` to serve internal traffic.
 
 ## Requirements
@@ -11,7 +11,7 @@ one `internal` to serve internal traffic.
 
 ## Image repository and tag
 
-* Nginx IC image: `quay.io/kubernetes-ingress-controller/nginx-ingress-controller:0.26.1`
+* Nginx IC image: `quay.io/kubernetes-ingress-controller/nginx-ingress-controller:0.30.0`
 * Nginx IC repo: https://github.com/kubernetes/ingress-nginx
 
 ## Configuration
@@ -32,10 +32,10 @@ You can deploy Nginx Double by running following command in the root of the proj
 ## Alerts
 
 Followings Prometheus [alerts](https://prometheus.io/docs/prometheus/latest/configuration/alerting_rules/) are already
-defined for this package. 
- 
-### ingress-nginx.rules  
-| Parameter | Description | Severity | Interval | 
+defined for this package.
+
+### ingress-nginx.rules
+| Parameter | Description | Severity | Interval |
 |------|-------------|----------|:-----:|
 | NginxIngressDown | This alert fires if Promethes target discovery was not able to reach ingress-nginx-metrics in the last 15 minutes. | critical | 15m |
 | NginxIngressFailureRate | This alert fires if the failure rate (the rate of 5xx reponses) measured on a time window of 2 minutes was higher than 10% in the last 10 minutes. | critical | 10m |
@@ -48,4 +48,4 @@ defined for this package.
 
 ## License
 
-For license details please see [LICENSE](../../LICENSE) 
+For license details please see [LICENSE](../../LICENSE)

--- a/katalog/nginx/README.md
+++ b/katalog/nginx/README.md
@@ -11,7 +11,7 @@ Ingress Nginx is an Ingress Controller for [NGINX](https://nginx.org) webserver 
 
 ## Image repository and tag
 
-* Ingress Nginx image: `quay.io/kubernetes-ingress-controller/nginx-ingress-controller:0.26.1`
+* Ingress Nginx image: `quay.io/kubernetes-ingress-controller/nginx-ingress-controller:0.30.0`
 * Ingress Nginx repo: https://github.com/kubernetes/ingress-nginx
 
 
@@ -33,10 +33,10 @@ You can deploy Nginx by running following command in the root of the project:
 
 ## Alerts
 
-Followings Prometheus [alerts](https://prometheus.io/docs/prometheus/latest/configuration/alerting_rules/) are already defined for this package. 
- 
-### ingress-nginx.rules  
-| Parameter | Description | Severity | Interval | 
+Followings Prometheus [alerts](https://prometheus.io/docs/prometheus/latest/configuration/alerting_rules/) are already defined for this package.
+
+### ingress-nginx.rules
+| Parameter | Description | Severity | Interval |
 |------|-------------|----------|:-----:|
 | NginxIngressDown | This alert fires if Promethes target discovery was not able to reach ingress-nginx-metrics in the last 15 minutes. | critical | 15m |
 | NginxIngressFailureRate | This alert fires if the failure rate (the rate of 5xx reponses) measured on a time window of 2 minutes was higher than 10% in the last 10 minutes. | critical | 10m |
@@ -49,4 +49,4 @@ Followings Prometheus [alerts](https://prometheus.io/docs/prometheus/latest/conf
 
 ## License
 
-For license details please see [LICENSE](https://sighup.io/fury/license) 
+For license details please see [LICENSE](https://sighup.io/fury/license)

--- a/katalog/nginx/bases/controller/deployment.yml
+++ b/katalog/nginx/bases/controller/deployment.yml
@@ -16,7 +16,7 @@ spec:
         fsGroup: 33
       containers:
         - name: nginx-ingress-controller
-          image: quay.io/kubernetes-ingress-controller/nginx-ingress-controller:0.26.1
+          image: quay.io/kubernetes-ingress-controller/nginx-ingress-controller
           args:
             - /nginx-ingress-controller
             - --configmap=$(POD_NAMESPACE)/nginx-configuration

--- a/katalog/nginx/bases/controller/deployment.yml
+++ b/katalog/nginx/bases/controller/deployment.yml
@@ -13,7 +13,7 @@ spec:
     spec:
       serviceAccountName: nginx-ingress-serviceaccount
       securityContext:
-        fsGroup: 33
+        fsGroup: 101
       containers:
         - name: nginx-ingress-controller
           image: quay.io/kubernetes-ingress-controller/nginx-ingress-controller
@@ -30,9 +30,9 @@ spec:
                 - ALL
               add:
                 - NET_BIND_SERVICE
-            runAsUser: 33
+            runAsUser: 101
             runAsNonRoot: true
-            runAsGroup: 33
+            runAsGroup: 101
           env:
             - name: POD_NAME
               valueFrom:

--- a/katalog/nginx/bases/controller/kustomization.yaml
+++ b/katalog/nginx/bases/controller/kustomization.yaml
@@ -4,6 +4,10 @@ kind: Kustomization
 
 namespace: ingress-nginx
 
+images:
+  - name: quay.io/kubernetes-ingress-controller/nginx-ingress-controller
+    newTag: 0.30.0
+
 resources:
   - deployment.yml
   - cm.yml


### PR DESCRIPTION
The aim of this PR is to update ingress-nginx to 0.30.0

Summary of changes:
  - updated ingress-nginx to 0.30.0
  - updated ingress-nginx UID due to changes in the upstream project

No particular care has to be taken to update from Fury's current version (0.26.1) to 0.30.0.