### PR TITLE
Fix: add missing permissions

### DIFF
--- a/docs/releases/unreleased.md
+++ b/docs/releases/unreleased.md
@@ -5,7 +5,7 @@ This release includes some improvements TBD
 ## Changelog
 
 - Adds [cert-manager](../../katalog/cert-manager) dashboard.
-
+- Fixes rbac permissions of the `nginx-ingress-role` when using dual-nginx, giving permissions to both ingresses (internal and external) to use the needed configmaps.
 
 ## Upgrade path
 
@@ -14,4 +14,5 @@ To upgrade this core module from `v1.8.0` to `v1.9.0`, you need to download this
 
 ```bash
 kustomize build katalog/cert-manager | kubectl apply -f -
+kustomize build katalog/dual-nginx | kubectl apply -f -
 ```

--- a/katalog/dual-nginx/patch/rbac.yml
+++ b/katalog/dual-nginx/patch/rbac.yml
@@ -5,3 +5,6 @@
 - op: "replace"
   path: "/rules/1/resourceNames"
   value: ["ingress-controller-leader-external", "ingress-controller-leader-internal"]
+- op: "replace"
+  path: "/rules/6/resourceNames"
+  value: ["ingress-controller-leader-external", "ingress-controller-leader-internal"]

--- a/katalog/dual-nginx/patch/rbac.yml
+++ b/katalog/dual-nginx/patch/rbac.yml
@@ -3,8 +3,5 @@
 # license that can be found in the LICENSE file.
 
 - op: "replace"
-  path: "/rules/1/resourceNames"
-  value: ["ingress-controller-leader-external", "ingress-controller-leader-internal"]
-- op: "replace"
   path: "/rules/6/resourceNames"
   value: ["ingress-controller-leader-external", "ingress-controller-leader-internal"]

--- a/katalog/nginx/bases/configs/rbac.yml
+++ b/katalog/nginx/bases/configs/rbac.yml
@@ -135,6 +135,8 @@ rules:
       # This has to be adapted if you change either parameter
       # when launching the nginx-ingress-controller.
       - "ingress-controller-leader-nginx"
+      - "ingress-controller-leader-internal"
+      - "ingress-controller-leader-external"
     verbs:
       - get
       - update

--- a/katalog/nginx/bases/configs/rbac.yml
+++ b/katalog/nginx/bases/configs/rbac.yml
@@ -135,8 +135,6 @@ rules:
       # This has to be adapted if you change either parameter
       # when launching the nginx-ingress-controller.
       - "ingress-controller-leader-nginx"
-      - "ingress-controller-leader-internal"
-      - "ingress-controller-leader-external"
     verbs:
       - get
       - update


### PR DESCRIPTION
Without these permissions, the dual nginx ingress is unable to elect a leader.
Hence, the ingress is not able to set the address on ingresses (and it generates more errors in cascade).

Reference for the fix: https://github.com/kubernetes/ingress-nginx/issues/1976#issuecomment-469020715