### PR TITLE
Release 1.9.0

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,7 +1,7 @@
 [bumpversion]
 commit = True
 tag = True
-current_version = 1.8.2
+current_version = 1.9.0-rc5
 parse = (?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)(\-rc(?P<rc>\d+))?
 serialize = 
 	{major}.{minor}.{patch}-rc{rc}

--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,7 +1,7 @@
 [bumpversion]
 commit = True
 tag = True
-current_version = 1.9.0-rc6
+current_version = 1.9.0-rc7
 parse = (?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)(\-rc(?P<rc>\d+))?
 serialize = 
 	{major}.{minor}.{patch}-rc{rc}

--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,7 +1,7 @@
 [bumpversion]
 commit = True
 tag = True
-current_version = 1.9.0-rc5
+current_version = 1.9.0-rc6
 parse = (?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)(\-rc(?P<rc>\d+))?
 serialize = 
 	{major}.{minor}.{patch}-rc{rc}

--- a/.drone.yml
+++ b/.drone.yml
@@ -116,7 +116,7 @@ trigger:
 
 steps:
   - name: init
-    image: quay.io/sighup/e2e-testing-drone-plugin:v0.8.1
+    image: quay.io/sighup/e2e-testing-drone-plugin:v0.9.0
     pull: always
     volumes:
     - name: shared
@@ -140,6 +140,10 @@ steps:
         from_secret: vsphere_password
       vsphere_user:
         from_secret: vsphere_user
+      dockerhub_username:
+        from_secret: dockerhub_username
+      dockerhub_password:
+        from_secret: dockerhub_password
 
   - name: e2e
     image: quay.io/sighup/e2e-testing:1.1.0_0.2.2_2.16.1_1.4.0_1.17.11_3.3.0_2.4.1
@@ -156,7 +160,7 @@ steps:
       - bats -t katalog/tests/nginx-ldap-auth.sh
 
   - name: destroy
-    image: quay.io/sighup/e2e-testing-drone-plugin:v0.8.1
+    image: quay.io/sighup/e2e-testing-drone-plugin:v0.9.0
     depends_on: [ e2e ]
     settings:
       action: destroy
@@ -175,6 +179,10 @@ steps:
         from_secret: vsphere_password
       vsphere_user:
         from_secret: vsphere_user
+      dockerhub_username:
+        from_secret: dockerhub_username
+      dockerhub_password:
+        from_secret: dockerhub_password
     when:
       status:
       - success
@@ -202,7 +210,7 @@ trigger:
 
 steps:
   - name: init
-    image: quay.io/sighup/e2e-testing-drone-plugin:v0.8.1
+    image: quay.io/sighup/e2e-testing-drone-plugin:v0.9.0
     pull: always
     volumes:
     - name: shared
@@ -226,6 +234,10 @@ steps:
         from_secret: vsphere_password
       vsphere_user:
         from_secret: vsphere_user
+      dockerhub_username:
+        from_secret: dockerhub_username
+      dockerhub_password:
+        from_secret: dockerhub_password
 
   - name: e2e
     image: quay.io/sighup/e2e-testing:1.1.0_0.2.2_2.16.1_1.4.0_1.18.8_3.3.0_2.4.1
@@ -242,7 +254,7 @@ steps:
       - bats -t katalog/tests/nginx-ldap-auth.sh
 
   - name: destroy
-    image: quay.io/sighup/e2e-testing-drone-plugin:v0.8.1
+    image: quay.io/sighup/e2e-testing-drone-plugin:v0.9.0
     depends_on: [ e2e ]
     settings:
       action: destroy
@@ -261,6 +273,10 @@ steps:
         from_secret: vsphere_password
       vsphere_user:
         from_secret: vsphere_user
+      dockerhub_username:
+        from_secret: dockerhub_username
+      dockerhub_password:
+        from_secret: dockerhub_password
     when:
       status:
       - success
@@ -288,7 +304,7 @@ trigger:
 
 steps:
   - name: init
-    image: quay.io/sighup/e2e-testing-drone-plugin:v0.8.1
+    image: quay.io/sighup/e2e-testing-drone-plugin:v0.9.0
     pull: always
     volumes:
     - name: shared
@@ -312,6 +328,10 @@ steps:
         from_secret: vsphere_password
       vsphere_user:
         from_secret: vsphere_user
+      dockerhub_username:
+        from_secret: dockerhub_username
+      dockerhub_password:
+        from_secret: dockerhub_password
 
   - name: e2e
     image: quay.io/sighup/e2e-testing:1.1.0_0.2.2_2.16.1_1.4.0_1.19.4_3.3.0_2.4.1
@@ -328,7 +348,7 @@ steps:
       - bats -t katalog/tests/nginx-ldap-auth.sh
 
   - name: destroy
-    image: quay.io/sighup/e2e-testing-drone-plugin:v0.8.1
+    image: quay.io/sighup/e2e-testing-drone-plugin:v0.9.0
     pull: always
     depends_on: [ e2e ]
     settings:
@@ -348,6 +368,10 @@ steps:
         from_secret: vsphere_password
       vsphere_user:
         from_secret: vsphere_user
+      dockerhub_username:
+        from_secret: dockerhub_username
+      dockerhub_password:
+        from_secret: dockerhub_password
     when:
       status:
       - success
@@ -375,7 +399,7 @@ trigger:
 
 steps:
   - name: init
-    image: quay.io/sighup/e2e-testing-drone-plugin:v0.8.1
+    image: quay.io/sighup/e2e-testing-drone-plugin:v0.9.0
     pull: always
     volumes:
     - name: shared
@@ -399,6 +423,10 @@ steps:
         from_secret: vsphere_password
       vsphere_user:
         from_secret: vsphere_user
+      dockerhub_username:
+        from_secret: dockerhub_username
+      dockerhub_password:
+        from_secret: dockerhub_password
 
   - name: e2e
     image: quay.io/sighup/e2e-testing:1.1.0_0.2.2_2.16.1_1.4.0_1.20.0_3.3.0_2.4.1
@@ -415,7 +443,7 @@ steps:
       - bats -t katalog/tests/nginx-ldap-auth.sh
 
   - name: destroy
-    image: quay.io/sighup/e2e-testing-drone-plugin:v0.8.1
+    image: quay.io/sighup/e2e-testing-drone-plugin:v0.9.0
     depends_on: [ e2e ]
     settings:
       action: destroy
@@ -434,6 +462,10 @@ steps:
         from_secret: vsphere_password
       vsphere_user:
         from_secret: vsphere_user
+      dockerhub_username:
+        from_secret: dockerhub_username
+      dockerhub_password:
+        from_secret: dockerhub_password
     when:
       status:
       - success

--- a/.drone.yml
+++ b/.drone.yml
@@ -116,7 +116,7 @@ trigger:
 
 steps:
   - name: init
-    image: quay.io/sighup/e2e-testing-drone-plugin:v0.8.0
+    image: quay.io/sighup/e2e-testing-drone-plugin:v0.8.1
     pull: always
     volumes:
     - name: shared
@@ -156,7 +156,7 @@ steps:
       - bats -t katalog/tests/nginx-ldap-auth.sh
 
   - name: destroy
-    image: quay.io/sighup/e2e-testing-drone-plugin:v0.8.0
+    image: quay.io/sighup/e2e-testing-drone-plugin:v0.8.1
     depends_on: [ e2e ]
     settings:
       action: destroy
@@ -202,7 +202,7 @@ trigger:
 
 steps:
   - name: init
-    image: quay.io/sighup/e2e-testing-drone-plugin:v0.8.0
+    image: quay.io/sighup/e2e-testing-drone-plugin:v0.8.1
     pull: always
     volumes:
     - name: shared
@@ -242,7 +242,7 @@ steps:
       - bats -t katalog/tests/nginx-ldap-auth.sh
 
   - name: destroy
-    image: quay.io/sighup/e2e-testing-drone-plugin:v0.8.0
+    image: quay.io/sighup/e2e-testing-drone-plugin:v0.8.1
     depends_on: [ e2e ]
     settings:
       action: destroy
@@ -288,7 +288,7 @@ trigger:
 
 steps:
   - name: init
-    image: quay.io/sighup/e2e-testing-drone-plugin:v0.8.0
+    image: quay.io/sighup/e2e-testing-drone-plugin:v0.8.1
     pull: always
     volumes:
     - name: shared
@@ -328,7 +328,7 @@ steps:
       - bats -t katalog/tests/nginx-ldap-auth.sh
 
   - name: destroy
-    image: quay.io/sighup/e2e-testing-drone-plugin:v0.8.0
+    image: quay.io/sighup/e2e-testing-drone-plugin:v0.8.1
     pull: always
     depends_on: [ e2e ]
     settings:
@@ -375,7 +375,7 @@ trigger:
 
 steps:
   - name: init
-    image: quay.io/sighup/e2e-testing-drone-plugin:v0.8.0
+    image: quay.io/sighup/e2e-testing-drone-plugin:v0.8.1
     pull: always
     volumes:
     - name: shared
@@ -415,7 +415,7 @@ steps:
       - bats -t katalog/tests/nginx-ldap-auth.sh
 
   - name: destroy
-    image: quay.io/sighup/e2e-testing-drone-plugin:v0.8.0
+    image: quay.io/sighup/e2e-testing-drone-plugin:v0.8.1
     depends_on: [ e2e ]
     settings:
       action: destroy

--- a/.drone.yml
+++ b/.drone.yml
@@ -100,92 +100,6 @@ steps:
 
 ---
 kind: pipeline
-name: e2e-kubernetes-1.16
-
-depends_on:
-  - policeman
-
-platform:
-  os: linux
-  arch: amd64
-
-trigger:
-  ref:
-    include:
-      - refs/tags/**
-
-steps:
-  - name: init
-    image: quay.io/sighup/e2e-testing-drone-plugin:v0.7.1
-    pull: always
-    volumes:
-    - name: shared
-      path: /shared
-    depends_on: [ clone ]
-    settings:
-      action: cluster-116
-      pipeline_id: cluster-116
-      instance_path: /shared
-      aws_default_region:
-        from_secret: aws_region
-      aws_access_key_id:
-        from_secret: aws_access_key_id
-      aws_secret_access_key:
-        from_secret: aws_secret_access_key
-      terraform_tf_states_bucket_name:
-        from_secret: terraform_tf_states_bucket_name
-      vsphere_server:
-        from_secret: vsphere_server
-      vsphere_password:
-        from_secret: vsphere_password
-      vsphere_user:
-        from_secret: vsphere_user
-
-  - name: e2e
-    image: quay.io/sighup/e2e-testing:1.1.0_0.2.2_2.16.1_1.4.0_1.16.15_3.3.0_2.4.1
-    pull: always
-    volumes:
-    - name: shared
-      path: /shared
-    depends_on: [ init ]
-    commands:
-      - export CLUSTER_NAME=116
-      - export INSTANCE_IP=$(cat /shared/machine/ip)
-      - export KUBECONFIG=/shared/kube/kubeconfig-116
-      - bats -t katalog/tests/tests.bats
-      - bats -t katalog/tests/nginx-ldap-auth.sh
-
-  - name: destroy
-    image: quay.io/sighup/e2e-testing-drone-plugin:v0.7.1
-    depends_on: [ e2e ]
-    settings:
-      action: destroy
-      pipeline_id: cluster-116
-      aws_default_region:
-        from_secret: aws_region
-      aws_access_key_id:
-        from_secret: aws_access_key_id
-      aws_secret_access_key:
-        from_secret: aws_secret_access_key
-      terraform_tf_states_bucket_name:
-        from_secret: terraform_tf_states_bucket_name
-      vsphere_server:
-        from_secret: vsphere_server
-      vsphere_password:
-        from_secret: vsphere_password
-      vsphere_user:
-        from_secret: vsphere_user
-    when:
-      status:
-      - success
-      - failure
-
-volumes:
-- name: shared
-  temp: {}
-
----
-kind: pipeline
 name: e2e-kubernetes-1.17
 
 depends_on:
@@ -202,7 +116,7 @@ trigger:
 
 steps:
   - name: init
-    image: quay.io/sighup/e2e-testing-drone-plugin:v0.7.1
+    image: quay.io/sighup/e2e-testing-drone-plugin:v0.8.0
     pull: always
     volumes:
     - name: shared
@@ -242,7 +156,7 @@ steps:
       - bats -t katalog/tests/nginx-ldap-auth.sh
 
   - name: destroy
-    image: quay.io/sighup/e2e-testing-drone-plugin:v0.7.1
+    image: quay.io/sighup/e2e-testing-drone-plugin:v0.8.0
     depends_on: [ e2e ]
     settings:
       action: destroy
@@ -288,7 +202,7 @@ trigger:
 
 steps:
   - name: init
-    image: quay.io/sighup/e2e-testing-drone-plugin:v0.7.1
+    image: quay.io/sighup/e2e-testing-drone-plugin:v0.8.0
     pull: always
     volumes:
     - name: shared
@@ -328,7 +242,7 @@ steps:
       - bats -t katalog/tests/nginx-ldap-auth.sh
 
   - name: destroy
-    image: quay.io/sighup/e2e-testing-drone-plugin:v0.7.1
+    image: quay.io/sighup/e2e-testing-drone-plugin:v0.8.0
     depends_on: [ e2e ]
     settings:
       action: destroy
@@ -360,6 +274,9 @@ volumes:
 kind: pipeline
 name: e2e-kubernetes-1.19
 
+depends_on:
+  - policeman
+
 platform:
   os: linux
   arch: amd64
@@ -369,12 +286,9 @@ trigger:
     include:
       - refs/tags/**
 
-depends_on:
-  - policeman
-
 steps:
   - name: init
-    image: quay.io/sighup/e2e-testing-drone-plugin:v0.7.1
+    image: quay.io/sighup/e2e-testing-drone-plugin:v0.8.0
     pull: always
     volumes:
     - name: shared
@@ -400,7 +314,7 @@ steps:
         from_secret: vsphere_user
 
   - name: e2e
-    image: quay.io/sighup/e2e-testing:1.1.0_0.2.2_2.16.1_1.4.0_1.19.0_3.3.0_2.4.1
+    image: quay.io/sighup/e2e-testing:1.1.0_0.2.2_2.16.1_1.4.0_1.19.4_3.3.0_2.4.1
     pull: always
     volumes:
     - name: shared
@@ -414,7 +328,7 @@ steps:
       - bats -t katalog/tests/nginx-ldap-auth.sh
 
   - name: destroy
-    image: quay.io/sighup/e2e-testing-drone-plugin:v0.7.1
+    image: quay.io/sighup/e2e-testing-drone-plugin:v0.8.0
     pull: always
     depends_on: [ e2e ]
     settings:
@@ -445,12 +359,98 @@ volumes:
 
 ---
 kind: pipeline
+name: e2e-kubernetes-1.20
+
+depends_on:
+  - policeman
+
+platform:
+  os: linux
+  arch: amd64
+
+trigger:
+  ref:
+    include:
+      - refs/tags/**
+
+steps:
+  - name: init
+    image: quay.io/sighup/e2e-testing-drone-plugin:v0.8.0
+    pull: always
+    volumes:
+    - name: shared
+      path: /shared
+    depends_on: [ clone ]
+    settings:
+      action: cluster-120
+      pipeline_id: cluster-120
+      instance_path: /shared
+      aws_default_region:
+        from_secret: aws_region
+      aws_access_key_id:
+        from_secret: aws_access_key_id
+      aws_secret_access_key:
+        from_secret: aws_secret_access_key
+      terraform_tf_states_bucket_name:
+        from_secret: terraform_tf_states_bucket_name
+      vsphere_server:
+        from_secret: vsphere_server
+      vsphere_password:
+        from_secret: vsphere_password
+      vsphere_user:
+        from_secret: vsphere_user
+
+  - name: e2e
+    image: quay.io/sighup/e2e-testing:1.1.0_0.2.2_2.16.1_1.4.0_1.20.0_3.3.0_2.4.1
+    pull: always
+    volumes:
+    - name: shared
+      path: /shared
+    depends_on: [ init ]
+    commands:
+      - export CLUSTER_NAME=120
+      - export INSTANCE_IP=$(cat /shared/machine/ip)
+      - export KUBECONFIG=/shared/kube/kubeconfig-120
+      - bats -t katalog/tests/tests.bats
+      - bats -t katalog/tests/nginx-ldap-auth.sh
+
+  - name: destroy
+    image: quay.io/sighup/e2e-testing-drone-plugin:v0.8.0
+    depends_on: [ e2e ]
+    settings:
+      action: destroy
+      pipeline_id: cluster-120
+      aws_default_region:
+        from_secret: aws_region
+      aws_access_key_id:
+        from_secret: aws_access_key_id
+      aws_secret_access_key:
+        from_secret: aws_secret_access_key
+      terraform_tf_states_bucket_name:
+        from_secret: terraform_tf_states_bucket_name
+      vsphere_server:
+        from_secret: vsphere_server
+      vsphere_password:
+        from_secret: vsphere_password
+      vsphere_user:
+        from_secret: vsphere_user
+    when:
+      status:
+      - success
+      - failure
+
+volumes:
+- name: shared
+  temp: {}
+
+---
+kind: pipeline
 name: release
 
 depends_on:
-  - e2e-kubernetes-1.16
   - e2e-kubernetes-1.17
   - e2e-kubernetes-1.18
+  - e2e-kubernetes-1.19
 
 platform:
   os: linux

--- a/README.md
+++ b/README.md
@@ -9,33 +9,34 @@ The following packages are included in Fury Kubernetes Ingress katalog:
 
 - [cert-manager](katalog/cert-manager): cert-manager is a Kubernetes
 add-on to automate the management and issuance of TLS certificates
-from various issuing sources. Version: **v1.0.1**
+from various issuing sources. Version: **v1.1.0**
 - [forecastle](katalog/forecastle): Forecastle gives you access to a control
 panel where you can see your running applications and access them
-on Kubernetes. Version: **1.0.57**.
+on Kubernetes. Version: **1.0.61**.
 - [nginx](katalog/nginx): The NGINX Ingress Controller for Kubernetes
-provides delivery services for Kubernetes applications. Version: **0.35.0**
+provides delivery services for Kubernetes applications. Version: **0.42.0**
 - [dual-nginx](katalog/dual-nginx): It deploys two identical NGINX ingress controllers
-but with two different scopes: public/external and private/internal. Version: **0.35.0**
+but with two different scopes: public/external and private/internal. Version: **0.42.0**
 - [nginx-ldap-auth](katalog/nginx-ldap-auth): Use this to provide an ingress authentication over LDAP for
 Kubernetes. Version: **1.0.6**
 
 
 ## Compatibility
 
-| Module Version / Kubernetes Version | 1.14.X             | 1.15.X             | 1.16.X             | 1.17.X             | 1.18.X             | 1.19.X             |
-|-------------------------------------|:------------------:|:------------------:|:------------------:|:------------------:|:------------------:|:------------------:|
-| v1.1.0                              |                    |                    |                    |                    |                    |                    |
-| v1.2.0                              | :white_check_mark: | :white_check_mark: | :white_check_mark: |                    |                    |                    |
-| v1.3.0                              | :white_check_mark: | :white_check_mark: | :white_check_mark: |                    |                    |                    |
-| v1.4.0                              | :white_check_mark: | :white_check_mark: | :white_check_mark: |                    |                    |                    |
-| v1.5.0                              | :white_check_mark: | :white_check_mark: | :white_check_mark: |                    |                    |                    |
-| v1.6.0                              | :white_check_mark: | :white_check_mark: | :white_check_mark: |                    |                    |                    |
-| v1.6.1                              | :white_check_mark: | :white_check_mark: | :white_check_mark: |                    |                    |                    |
-| v1.7.0                              |                    |                    | :white_check_mark: | :white_check_mark: | :white_check_mark: |                    |
-| v1.8.0                              |                    |                    | :white_check_mark: | :white_check_mark: | :white_check_mark: |      :warning:     |
-| v1.8.1                              |                    |                    | :white_check_mark: | :white_check_mark: | :white_check_mark: |      :warning:     |
-| v1.8.2                              |                    |                    | :white_check_mark: | :white_check_mark: | :white_check_mark: |      :warning:     |
+| Module Version / Kubernetes Version | 1.14.X             | 1.15.X             | 1.16.X             | 1.17.X             | 1.18.X             | 1.19.X             | 1.20.X             |
+|-------------------------------------|:------------------:|:------------------:|:------------------:|:------------------:|:------------------:|:------------------:|:------------------:|
+| v1.1.0                              |                    |                    |                    |                    |                    |                    |                    |
+| v1.2.0                              | :white_check_mark: | :white_check_mark: | :white_check_mark: |                    |                    |                    |                    |
+| v1.3.0                              | :white_check_mark: | :white_check_mark: | :white_check_mark: |                    |                    |                    |                    |
+| v1.4.0                              | :white_check_mark: | :white_check_mark: | :white_check_mark: |                    |                    |                    |                    |
+| v1.5.0                              | :white_check_mark: | :white_check_mark: | :white_check_mark: |                    |                    |                    |                    |
+| v1.6.0                              | :white_check_mark: | :white_check_mark: | :white_check_mark: |                    |                    |                    |                    |
+| v1.6.1                              | :white_check_mark: | :white_check_mark: | :white_check_mark: |                    |                    |                    |                    |
+| v1.7.0                              |                    |                    | :white_check_mark: | :white_check_mark: | :white_check_mark: |                    |                    |
+| v1.8.0                              |                    |                    | :white_check_mark: | :white_check_mark: | :white_check_mark: |      :warning:     |                    |
+| v1.8.1                              |                    |                    | :white_check_mark: | :white_check_mark: | :white_check_mark: |      :warning:     |                    |
+| v1.8.2                              |                    |                    | :white_check_mark: | :white_check_mark: | :white_check_mark: |      :warning:     |                    |
+| v1.9.0                              |                    |                    |                    | :white_check_mark: | :white_check_mark: | :white_check_mark: |      :warning:     |
 
 - :white_check_mark: Compatible
 - :warning: Has issues
@@ -43,7 +44,7 @@ Kubernetes. Version: **1.0.6**
 
 ### Warning
 
-- :warning: : module version: `v1.8.0` and Kubernetes Version: `1.19.x`. It works as expected. Marked as warning
+- :warning: : module version: `v1.9.0` and Kubernetes Version: `1.20.x`. It works as expected. Marked as warning
 because it is not officially supported by [SIGHUP](https://sighup.io).
 
 ## LICENSE

--- a/docs/releases/v1.9.0.md
+++ b/docs/releases/v1.9.0.md
@@ -19,6 +19,7 @@ release.
   - Deprecate Kubernetes 1.16 support.
   - Kubernetes 1.19 is considered stable.
   - Add tech-preview support to Kubernetes 1.20.
+- All the container images come from the SIGHUP registry to avoid rate limits.
 
 ## Upgrade path
 

--- a/docs/releases/v1.9.0.md
+++ b/docs/releases/v1.9.0.md
@@ -1,4 +1,4 @@
-# Ingress Core Module version 1.8.2
+# Ingress Core Module version 1.9.0
 
 SIGHUP team maintains this module updated and tested. That is the main reason why we worked on this new release.
 With the Kubernetes 1.20 release, it became the perfect time to start testing this module against this Kubernetes
@@ -18,7 +18,7 @@ release.
 - Kubernetes support:
   - Deprecate Kubernetes 1.16 support.
   - Kubernetes 1.19 is considered stable.
-  - Add tech-preview support to Kubernete 1.20.
+  - Add tech-preview support to Kubernetes 1.20.
 
 ## Upgrade path
 

--- a/docs/releases/v1.9.0.md
+++ b/docs/releases/v1.9.0.md
@@ -9,7 +9,7 @@ release.
 - Upgrade [cert-manager](../../katalog/cert-manager). From v1.0.1 to
 [v1.1.0](https://github.com/jetstack/cert-manager/releases/tag/v1.1.0)
 - Upgrade [nginx-ingress-controller](../../katalog/nginx) and its variants
-(from v0.35.0 to [v0.42.0](https://github.com/kubernetes/ingress-nginx/releases/tag/controller-v0.42.0)):
+(from v0.35.0 to [v0.43.0](https://github.com/kubernetes/ingress-nginx/releases/tag/controller-v0.43.0)):
   - [dual-nginx](../../katalog/dual-nginx)
   - [nginx-gke](../../katalog/nginx-gke)
   - [nginx-ovh](../../katalog/nginx-ovh)

--- a/docs/releases/v1.9.0.md
+++ b/docs/releases/v1.9.0.md
@@ -1,0 +1,40 @@
+# Ingress Core Module version 1.8.2
+
+SIGHUP team maintains this module updated and tested. That is the main reason why we worked on this new release.
+With the Kubernetes 1.20 release, it became the perfect time to start testing this module against this Kubernetes
+release.
+
+## Changelog
+
+- Upgrade [cert-manager](../../katalog/cert-manager). From v1.0.1 to
+[v1.1.0](https://github.com/jetstack/cert-manager/releases/tag/v1.1.0)
+- Upgrade [nginx-ingress-controller](../../katalog/nginx) and its variants
+(from v0.35.0 to [v0.42.0](https://github.com/kubernetes/ingress-nginx/releases/tag/controller-v0.42.0)):
+  - [dual-nginx](../../katalog/dual-nginx)
+  - [nginx-gke](../../katalog/nginx-gke)
+  - [nginx-ovh](../../katalog/nginx-ovh)
+- Upgrade [forecastle](../../katalog/forecastle). From 1.0.57 to
+[1.0.61](https://github.com/stakater/Forecastle/releases/tag/v1.0.61)
+- Kubernetes support:
+  - Deprecate Kubernetes 1.16 support.
+  - Kubernetes 1.19 is considered stable.
+  - Add tech-preview support to Kubernete 1.20.
+
+## Upgrade path
+
+To upgrade this core module from `v1.8.2` to `v1.9.0`, you need to download this new version, then apply the
+`kustomize` projects. No further action is required.
+
+```bash
+kustomize build katalog/cert-manager | kubectl apply -f -
+# And
+kustomize build katalog/forecastle | kubectl apply -f -
+# And
+kustomize build katalog/nginx | kubectl apply -f -
+# Or
+kustomize build katalog/dual-nginx | kubectl apply -f -
+# Or
+kustomize build katalog/nginx-gke | kubectl apply -f -
+# Or
+kustomize build katalog/nginx-ovh | kubectl apply -f -
+```

--- a/examples/nginx-config/Furyfile.yml
+++ b/examples/nginx-config/Furyfile.yml
@@ -4,5 +4,5 @@
 
 bases:
   - name: ingress/nginx
-    version: v1.9.0-rc6
+    version: v1.9.0-rc7
 

--- a/examples/nginx-config/Furyfile.yml
+++ b/examples/nginx-config/Furyfile.yml
@@ -4,5 +4,5 @@
 
 bases:
   - name: ingress/nginx
-    version: v1.9.0-rc5
+    version: v1.9.0-rc6
 

--- a/examples/nginx-config/Furyfile.yml
+++ b/examples/nginx-config/Furyfile.yml
@@ -4,5 +4,5 @@
 
 bases:
   - name: ingress/nginx
-    version: v1.8.2
+    version: v1.9.0-rc5
 

--- a/examples/nginx-default-ssl-certificate/Furyfile.yml
+++ b/examples/nginx-default-ssl-certificate/Furyfile.yml
@@ -4,5 +4,5 @@
 
 bases:
   - name: ingress/nginx
-    version: v1.9.0-rc6
+    version: v1.9.0-rc7
 

--- a/examples/nginx-default-ssl-certificate/Furyfile.yml
+++ b/examples/nginx-default-ssl-certificate/Furyfile.yml
@@ -4,5 +4,5 @@
 
 bases:
   - name: ingress/nginx
-    version: v1.9.0-rc5
+    version: v1.9.0-rc6
 

--- a/examples/nginx-default-ssl-certificate/Furyfile.yml
+++ b/examples/nginx-default-ssl-certificate/Furyfile.yml
@@ -4,5 +4,5 @@
 
 bases:
   - name: ingress/nginx
-    version: v1.8.2
+    version: v1.9.0-rc5
 

--- a/examples/nginx-ldap-auth/Furyfile.yml
+++ b/examples/nginx-ldap-auth/Furyfile.yml
@@ -4,4 +4,4 @@
 
 bases:
   - name: ingress/nginx-ldap-auth
-    version: v1.9.0-rc6
+    version: v1.9.0-rc7

--- a/examples/nginx-ldap-auth/Furyfile.yml
+++ b/examples/nginx-ldap-auth/Furyfile.yml
@@ -4,4 +4,4 @@
 
 bases:
   - name: ingress/nginx-ldap-auth
-    version: v1.9.0-rc5
+    version: v1.9.0-rc6

--- a/examples/nginx-ldap-auth/Furyfile.yml
+++ b/examples/nginx-ldap-auth/Furyfile.yml
@@ -4,4 +4,4 @@
 
 bases:
   - name: ingress/nginx-ldap-auth
-    version: v1.8.2
+    version: v1.9.0-rc5

--- a/katalog/cert-manager/README.md
+++ b/katalog/cert-manager/README.md
@@ -9,12 +9,12 @@ Encrypt](https://letsencrypt.org/) Certificate Authority.
 
 ## Requirements
 
-- Kubernetes >= `1.16.0`
+- Kubernetes >= `1.17.0`
 - Kustomize >= `v3`
 
 ## Image repository and tag
 
-- Cert Manager image: `quay.io/jetstack/cert-manager-controller:v1.0.1`
+- Cert Manager image: `quay.io/jetstack/cert-manager-controller:v1.1.0`
 - Cert Manager repo: [https://github.com/jetstack/cert-manager](https://github.com/jetstack/cert-manager)
 - Cert Manager documentation: [https://cert-manager.io/docs/](https://cert-manager.io/docs/)
 
@@ -57,7 +57,7 @@ and under the `patches/dual-nginx.yml`:
   value: "external"
 ```
 
-this is only needed when you'll use the the `dual-nginx` because the default is the `nginx` single node
+this is only needed when you'll use the `dual-nginx` because the default is the `nginx` single node
 
 Once do that, you just need to hit:
 

--- a/katalog/cert-manager/cainjector/kustomization.yaml
+++ b/katalog/cert-manager/cainjector/kustomization.yaml
@@ -10,7 +10,7 @@ namespace: cert-manager
 
 images:
   - name: quay.io/jetstack/cert-manager-cainjector
-    newTag: v1.0.1
+    newTag: v1.1.0
 
 commonLabels:
   app: cainjector

--- a/katalog/cert-manager/cainjector/kustomization.yaml
+++ b/katalog/cert-manager/cainjector/kustomization.yaml
@@ -10,6 +10,7 @@ namespace: cert-manager
 
 images:
   - name: quay.io/jetstack/cert-manager-cainjector
+    newName: reg.sighup.io/sighupio/fury/jetstack/cert-manager-cainjector
     newTag: v1.1.0
 
 commonLabels:

--- a/katalog/cert-manager/cert-manager-controller/kustomization.yaml
+++ b/katalog/cert-manager/cert-manager-controller/kustomization.yaml
@@ -10,7 +10,7 @@ namespace: cert-manager
 
 images:
   - name: quay.io/jetstack/cert-manager-controller
-    newTag: v1.0.1
+    newTag: v1.1.0
 
 commonLabels:
   app: cert-manager

--- a/katalog/cert-manager/cert-manager-controller/kustomization.yaml
+++ b/katalog/cert-manager/cert-manager-controller/kustomization.yaml
@@ -10,6 +10,7 @@ namespace: cert-manager
 
 images:
   - name: quay.io/jetstack/cert-manager-controller
+    newName: reg.sighup.io/sighupio/fury/jetstack/cert-manager-controller
     newTag: v1.1.0
 
 commonLabels:

--- a/katalog/cert-manager/kustomization.yaml
+++ b/katalog/cert-manager/kustomization.yaml
@@ -6,14 +6,17 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 
-bases:
+resources:
   - cainjector
   - cert-manager-controller
   - webhook
   - dashboards
 
 commonLabels:
-  app.kubernetes.io/version: 1.0.1
   app.kubernetes.io/component: cert-manager
   app.kubernetes.io/part-of: fury-kubernetes-ingress
   app.kubernetes.io/managed-by: kustomize
+
+transformers:
+  - version-label.yaml
+  - retrocompatible-version-label.yaml

--- a/katalog/cert-manager/retrocompatible-version-label.yaml
+++ b/katalog/cert-manager/retrocompatible-version-label.yaml
@@ -1,3 +1,7 @@
+# Copyright (c) 2020 SIGHUP s.r.l All rights reserved.
+# Use of this source code is governed by a BSD-style
+# license that can be found in the LICENSE file.
+
 apiVersion: builtin
 kind: LabelTransformer
 metadata:

--- a/katalog/cert-manager/retrocompatible-version-label.yaml
+++ b/katalog/cert-manager/retrocompatible-version-label.yaml
@@ -1,0 +1,11 @@
+apiVersion: builtin
+kind: LabelTransformer
+metadata:
+  name: retrocompatible-labels
+labels:
+  app.kubernetes.io/version: 1.0.1
+fieldSpecs:
+- path: spec/template/metadata/labels
+  create: false
+- path: spec/selector/matchLabels
+  create: false

--- a/katalog/cert-manager/version-label.yaml
+++ b/katalog/cert-manager/version-label.yaml
@@ -1,3 +1,7 @@
+# Copyright (c) 2020 SIGHUP s.r.l All rights reserved.
+# Use of this source code is governed by a BSD-style
+# license that can be found in the LICENSE file.
+
 apiVersion: builtin
 kind: LabelTransformer
 metadata:

--- a/katalog/cert-manager/version-label.yaml
+++ b/katalog/cert-manager/version-label.yaml
@@ -1,0 +1,9 @@
+apiVersion: builtin
+kind: LabelTransformer
+metadata:
+  name: global-labels
+labels:
+  app.kubernetes.io/version: 1.1.0
+fieldSpecs:
+- path: metadata/labels
+  create: false

--- a/katalog/cert-manager/webhook/kustomization.yaml
+++ b/katalog/cert-manager/webhook/kustomization.yaml
@@ -6,6 +6,7 @@
 
 images:
   - name: quay.io/jetstack/cert-manager-webhook
+    newName: reg.sighup.io/sighupio/fury/jetstack/cert-manager-webhook:v1.1.0
     newTag: v1.1.0
 
 commonLabels:

--- a/katalog/cert-manager/webhook/kustomization.yaml
+++ b/katalog/cert-manager/webhook/kustomization.yaml
@@ -6,7 +6,7 @@
 
 images:
   - name: quay.io/jetstack/cert-manager-webhook
-    newName: reg.sighup.io/sighupio/fury/jetstack/cert-manager-webhook:v1.1.0
+    newName: reg.sighup.io/sighupio/fury/jetstack/cert-manager-webhook
     newTag: v1.1.0
 
 commonLabels:

--- a/katalog/cert-manager/webhook/kustomization.yaml
+++ b/katalog/cert-manager/webhook/kustomization.yaml
@@ -6,7 +6,7 @@
 
 images:
   - name: quay.io/jetstack/cert-manager-webhook
-    newTag: v1.0.1
+    newTag: v1.1.0
 
 commonLabels:
   app: webhook

--- a/katalog/dual-nginx/README.md
+++ b/katalog/dual-nginx/README.md
@@ -11,7 +11,7 @@ one `internal` to serve internal traffic.
 
 ## Image repository and tag
 
-* Ingress NGINX image: `k8s.gcr.io/ingress-nginx/controller:v0.42.0`
+* Ingress NGINX image: `k8s.gcr.io/ingress-nginx/controller:v0.43.0`
 * Ingress NGINX repo: [https://github.com/kubernetes/ingress-nginx](https://github.com/kubernetes/ingress-nginx)
 
 ## Configuration

--- a/katalog/dual-nginx/README.md
+++ b/katalog/dual-nginx/README.md
@@ -6,7 +6,7 @@ one `internal` to serve internal traffic.
 
 ## Requirements
 
-- Kubernetes >= `1.14.0`
+- Kubernetes >= `1.17.0`
 - Kustomize >= `v3`
 
 ## Image repository and tag

--- a/katalog/dual-nginx/README.md
+++ b/katalog/dual-nginx/README.md
@@ -11,7 +11,7 @@ one `internal` to serve internal traffic.
 
 ## Image repository and tag
 
-* Ingress NGINX image: `k8s.gcr.io/ingress-nginx/controller:0.35.0`
+* Ingress NGINX image: `k8s.gcr.io/ingress-nginx/controller:v0.42.0`
 * Ingress NGINX repo: [https://github.com/kubernetes/ingress-nginx](https://github.com/kubernetes/ingress-nginx)
 
 ## Configuration

--- a/katalog/forecastle/README.md
+++ b/katalog/forecastle/README.md
@@ -8,7 +8,7 @@ to show all the applications running on Kubernetes exposed through an Ingress.
 
 
 ## Image repository and tag
-- Forecastle image: `docker.io/stakater/forecastle:v1.0.57`
+- Forecastle image: `docker.io/stakater/forecastle:v1.0.61`
 - Forecastl repo: [https://github.com/stakater/Forecastle](https://github.com/stakater/Forecastle)
 
 ## Configuration

--- a/katalog/forecastle/kustomization.yaml
+++ b/katalog/forecastle/kustomization.yaml
@@ -14,6 +14,7 @@ resources:
 
 images:
   - name: stakater/forecastle
+    newName: reg.sighup.io/sighupio/fury/stakater/forecastle
     newTag: v1.0.61
 
 configMapGenerator:

--- a/katalog/forecastle/kustomization.yaml
+++ b/katalog/forecastle/kustomization.yaml
@@ -14,7 +14,7 @@ resources:
 
 images:
   - name: stakater/forecastle
-    newTag: v1.0.57
+    newTag: v1.0.61
 
 configMapGenerator:
   - name: forecastle-config

--- a/katalog/nginx-gke/README.md
+++ b/katalog/nginx-gke/README.md
@@ -9,7 +9,7 @@ Ingress NGINX is an Ingress Controller for [NGINX](https://nginx.org) webserver 
 
 ## Image repository and tag
 
-* Ingress NGINX GKE image: `k8s.gcr.io/ingress-nginx/controller:v0.42.0`
+* Ingress NGINX GKE image: `k8s.gcr.io/ingress-nginx/controller:v0.43.0`
 * Ingress NGINX CKE repo: [https://github.com/kubernetes/ingress-nginx](https://github.com/kubernetes/ingress-nginx)
 
 

--- a/katalog/nginx-gke/README.md
+++ b/katalog/nginx-gke/README.md
@@ -4,12 +4,12 @@ Ingress NGINX is an Ingress Controller for [NGINX](https://nginx.org) webserver 
 
 ## Requirements
 
-- Kubernetes >= `1.10.0`
+- Kubernetes >= `1.17.0`
 - Kustomize >= `v1`
 
 ## Image repository and tag
 
-* Ingress NGINX GKE image: `quay.io/kubernetes-ingress-controller/nginx-ingress-controller:0.19.0`
+* Ingress NGINX GKE image: `k8s.gcr.io/ingress-nginx/controller:v0.42.0`
 * Ingress NGINX CKE repo: [https://github.com/kubernetes/ingress-nginx](https://github.com/kubernetes/ingress-nginx)
 
 

--- a/katalog/nginx-ldap-auth/kustomization.yaml
+++ b/katalog/nginx-ldap-auth/kustomization.yaml
@@ -8,6 +8,11 @@ kind: Kustomization
 
 namespace: ingress-nginx
 
+images:
+  - name: docker.io/tpimenta/nginx-ldap-auth
+    newName: reg.sighup.io/sighupio/fury/tpimenta/nginx-ldap-auth
+    newTag: v1.0.6
+
 commonLabels:
   app: nginx-ldap-auth
 

--- a/katalog/nginx-ldap-auth/nginx-ldap-auth.yaml
+++ b/katalog/nginx-ldap-auth/nginx-ldap-auth.yaml
@@ -29,7 +29,7 @@ spec:
         fsGroup: 2000
       serviceAccountName: nginx-ldap-auth
       containers:
-      - image: docker.io/tpimenta/nginx-ldap-auth:v1.0.6
+      - image: docker.io/tpimenta/nginx-ldap-auth
         name: nginx-ldap-auth
         securityContext:
           allowPrivilegeEscalation: false

--- a/katalog/nginx-ovh/README.md
+++ b/katalog/nginx-ovh/README.md
@@ -5,7 +5,7 @@ a Kubernetes native manner. This package deploys Ingress Controller for OVH Kube
 
 ## Requirements
 
-- Kubernetes >= `1.16.0`
+- Kubernetes >= `1.17.0`
 - Kustomize >= `v3.3.0`
 
 ## Image repository and tag

--- a/katalog/nginx-ovh/README.md
+++ b/katalog/nginx-ovh/README.md
@@ -10,7 +10,7 @@ a Kubernetes native manner. This package deploys Ingress Controller for OVH Kube
 
 ## Image repository and tag
 
-* Ingress NGINX OVH image: `k8s.gcr.io/ingress-nginx/controller:v0.35.0`
+* Ingress NGINX OVH image: `k8s.gcr.io/ingress-nginx/controller:v0.42.0`
 * Ingress NGINX repo: [https://github.com/kubernetes/ingress-nginx](https://github.com/kubernetes/ingress-nginx)
 
 

--- a/katalog/nginx-ovh/README.md
+++ b/katalog/nginx-ovh/README.md
@@ -10,7 +10,7 @@ a Kubernetes native manner. This package deploys Ingress Controller for OVH Kube
 
 ## Image repository and tag
 
-* Ingress NGINX OVH image: `k8s.gcr.io/ingress-nginx/controller:v0.42.0`
+* Ingress NGINX OVH image: `k8s.gcr.io/ingress-nginx/controller:v0.43.0`
 * Ingress NGINX repo: [https://github.com/kubernetes/ingress-nginx](https://github.com/kubernetes/ingress-nginx)
 
 

--- a/katalog/nginx/README.md
+++ b/katalog/nginx/README.md
@@ -11,7 +11,7 @@ it manages NGINX in a Kubernetes native manner. This package deploys Ingress Con
 
 ## Image repository and tag
 
-* Ingress NGINX image: `k8s.gcr.io/ingress-nginx/controller:v0.42.0`
+* Ingress NGINX image: `k8s.gcr.io/ingress-nginx/controller:v0.43.0`
 * Ingress NGINX repo: [https://github.com/kubernetes/ingress-nginx](https://github.com/kubernetes/ingress-nginx)
 
 ## Configuration

--- a/katalog/nginx/README.md
+++ b/katalog/nginx/README.md
@@ -6,12 +6,12 @@ it manages NGINX in a Kubernetes native manner. This package deploys Ingress Con
 
 ## Requirements
 
-- Kubernetes >= `1.14.0`
+- Kubernetes >= `1.17.0`
 - Kustomize >= `v3`
 
 ## Image repository and tag
 
-* Ingress NGINX image: `k8s.gcr.io/ingress-nginx/controller:0.35.0`
+* Ingress NGINX image: `k8s.gcr.io/ingress-nginx/controller:v0.42.0`
 * Ingress NGINX repo: [https://github.com/kubernetes/ingress-nginx](https://github.com/kubernetes/ingress-nginx)
 
 ## Configuration

--- a/katalog/nginx/bases/controller/deployment.yml
+++ b/katalog/nginx/bases/controller/deployment.yml
@@ -43,6 +43,7 @@ spec:
             runAsUser: 101
             runAsNonRoot: true
             runAsGroup: 101
+            allowPrivilegeEscalation: true
           env:
             - name: POD_NAME
               valueFrom:
@@ -52,6 +53,8 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: metadata.namespace
+            - name: LD_PRELOAD
+              value: /usr/local/lib/libmimalloc.so
           ports:
             - name: http
               containerPort: 8080
@@ -60,7 +63,7 @@ spec:
             - name: metrics
               containerPort: 10254
           livenessProbe:
-            failureThreshold: 3
+            failureThreshold: 5
             httpGet:
               path: /healthz
               port: 10254
@@ -75,6 +78,11 @@ spec:
               path: /healthz
               port: 10254
               scheme: HTTP
+            initialDelaySeconds: 10
             periodSeconds: 10
             successThreshold: 1
             timeoutSeconds: 1
+          resources:
+            requests:
+              cpu: 100m
+              memory: 90Mi

--- a/katalog/nginx/bases/controller/global-labels.yaml
+++ b/katalog/nginx/bases/controller/global-labels.yaml
@@ -1,0 +1,19 @@
+# Copyright (c) 2020 SIGHUP s.r.l All rights reserved.
+# Use of this source code is governed by a BSD-style
+# license that can be found in the LICENSE file.
+
+apiVersion: builtin
+kind: LabelTransformer
+metadata:
+  name: global-labels
+labels:
+  app.kubernetes.io/component: controller
+  app.kubernetes.io/part-of: fury-kubernetes-ingress
+  app.kubernetes.io/managed-by: kustomize
+  app.kubernetes.io/instance: fury
+  app.kubernetes.io/name: ingress-nginx
+fieldSpecs:
+- path: metadata/labels
+  create: false
+- path: spec/template/metadata/labels
+  create: false

--- a/katalog/nginx/bases/controller/kustomization.yaml
+++ b/katalog/nginx/bases/controller/kustomization.yaml
@@ -13,7 +13,7 @@ transformers:
 
 images:
   - name: k8s.gcr.io/ingress-nginx/controller
-    newTag: v0.42.0
+    newTag: v0.43.0
 
 resources:
   - deployment.yml

--- a/katalog/nginx/bases/controller/kustomization.yaml
+++ b/katalog/nginx/bases/controller/kustomization.yaml
@@ -13,6 +13,7 @@ transformers:
 
 images:
   - name: k8s.gcr.io/ingress-nginx/controller
+    newName: reg.sighup.io/sighupio/fury/ingress-nginx/controller
     newTag: v0.43.0
 
 resources:

--- a/katalog/nginx/bases/controller/kustomization.yaml
+++ b/katalog/nginx/bases/controller/kustomization.yaml
@@ -8,9 +8,12 @@ kind: Kustomization
 
 namespace: ingress-nginx
 
+transformers:
+  - global-labels.yaml
+
 images:
   - name: k8s.gcr.io/ingress-nginx/controller
-    newTag: v0.35.0
+    newTag: v0.42.0
 
 resources:
   - deployment.yml

--- a/katalog/tests/nginx-ldap-auth.sh
+++ b/katalog/tests/nginx-ldap-auth.sh
@@ -32,30 +32,17 @@ load ./helper
 @test "Setup httpbin demo project" {
     info
     setup_demo(){
-        kubectl create ns demo-nginx-ldap-auth
+        kubectl create ns demo-nginx-ldap-auth --dry-run -o yaml | kubectl apply -f -
         kubectl apply -f katalog/tests/nginx-ldap-auth/httpbin.yaml -n demo-nginx-ldap-auth
     }
     run setup_demo
     [ "$status" -eq 0 ]
 }
 
-@test "Test no-auth httpbin ingress demo project (cloud)" {
-    if [ "${INSTANCE_IP}" == "localhost" ]; then skip "This test was designed to be run on cloud instances"; fi
+@test "Test no-auth httpbin ingress demo project" {
     info
     test(){
-        http_code=$(curl "http://httpbin.${INSTANCE_IP}.nip.io:${CLUSTER_NAME}80/get" -s -o /dev/null -w "%{http_code}")
-        if [ "${http_code}" -ne "200" ]; then return 1; fi
-    }
-    loop_it test 30 2
-    status=${loop_it_result}
-    [ "$status" -eq 0 ]
-}
-
-@test "Test no-auth httpbin ingress demo project (local)" {
-    info
-    if [ "${INSTANCE_IP}" != "localhost" ]; then skip; fi
-    test(){
-        http_code=$(curl -H "Host: httpbin.${INSTANCE_IP}.nip.io" "http://${INSTANCE_IP}:${CLUSTER_NAME}80/get" -s -o /dev/null -w "%{http_code}")
+        http_code=$(curl -H "Host: ${INSTANCE_IP//./-}.nip.io" "http://${INSTANCE_IP}:${CLUSTER_NAME}80/get" -s -o /dev/null -w "%{http_code}")
         if [ "${http_code}" -ne "200" ]; then return 1; fi
     }
     loop_it test 30 2
@@ -115,11 +102,10 @@ load ./helper
     [ "$status" -eq 0 ]
 }
 
-@test "Users. Test no-auth secured httpbin ingress demo project (cloud)" {
+@test "Users. Test no-auth secured httpbin ingress demo project" {
     info
-    if [ "${INSTANCE_IP}" == "localhost" ]; then skip "This test was designed to be run on cloud instances"; fi
     test(){
-        http_code=$(curl "http://httpbin.${INSTANCE_IP}.nip.io:${CLUSTER_NAME}80/get" -s -o /dev/null -w "%{http_code}")
+        http_code=$(curl -H "Host: ${INSTANCE_IP//./-}.nip.io" "http://${INSTANCE_IP}:${CLUSTER_NAME}80/get" -s -o /dev/null -w "%{http_code}")
         if [ "${http_code}" -ne "401" ]; then return 1; fi
     }
     loop_it test 30 2
@@ -127,23 +113,10 @@ load ./helper
     [ "$status" -eq 0 ]
 }
 
-@test "Users. Test no-auth secured httpbin ingress demo project (local)" {
+@test "Users. Test auth httpbin secured ingress demo project" {
     info
-    if [ "${INSTANCE_IP}" != "localhost" ]; then skip; fi
     test(){
-        http_code=$(curl -H "Host: httpbin.${INSTANCE_IP}.nip.io" "http://${INSTANCE_IP}:${CLUSTER_NAME}80/get" -s -o /dev/null -w "%{http_code}")
-        if [ "${http_code}" -ne "401" ]; then return 1; fi
-    }
-    loop_it test 30 2
-    status=${loop_it_result}
-    [ "$status" -eq 0 ]
-}
-
-@test "Users. Test auth httpbin secured ingress demo project (cloud)" {
-    info
-    if [ "${INSTANCE_IP}" == "localhost" ]; then skip "This test was designed to be run on cloud instances"; fi
-    test(){
-        http_code=$(curl -u angel:angel "http://httpbin.${INSTANCE_IP}.nip.io:${CLUSTER_NAME}80/get" -s -o /dev/null -w "%{http_code}")
+        http_code=$(curl -u angel:angel -H "Host: ${INSTANCE_IP//./-}.nip.io" "http://${INSTANCE_IP}:${CLUSTER_NAME}80/get" -s -o /dev/null -w "%{http_code}")
         if [ "${http_code}" -ne "200" ]; then return 1; fi
     }
     loop_it test 30 2
@@ -151,35 +124,10 @@ load ./helper
     [ "$status" -eq 0 ]
 }
 
-@test "Users. Test auth httpbin secured ingress demo project (local)" {
+@test "Users. Test auth (no authorized) httpbin secured ingress demo project" {
     info
-    if [ "${INSTANCE_IP}" != "localhost" ]; then skip; fi
     test(){
-        http_code=$(curl -u angel:angel -H "Host: httpbin.${INSTANCE_IP}.nip.io" "http://${INSTANCE_IP}:${CLUSTER_NAME}80/get" -s -o /dev/null -w "%{http_code}")
-        if [ "${http_code}" -ne "200" ]; then return 1; fi
-    }
-    loop_it test 30 2
-    status=${loop_it_result}
-    [ "$status" -eq 0 ]
-}
-
-@test "Users. Test auth (no authorized) httpbin secured ingress demo project (cloud)" {
-    info
-    if [ "${INSTANCE_IP}" == "localhost" ]; then skip "This test was designed to be run on cloud instances"; fi
-    test(){
-        http_code=$(curl -u ramiro:ramiro "http://httpbin.${INSTANCE_IP}.nip.io:${CLUSTER_NAME}80/get" -s -o /dev/null -w "%{http_code}")
-        if [ "${http_code}" -ne "401" ]; then return 1; fi
-    }
-    loop_it test 30 2
-    status=${loop_it_result}
-    [ "$status" -eq 0 ]
-}
-
-@test "Users. Test auth (no authorized) httpbin secured ingress demo project (local)" {
-    info
-    if [ "${INSTANCE_IP}" != "localhost" ]; then skip; fi
-    test(){
-        http_code=$(curl -u ramiro:ramiro -H "Host: httpbin.${INSTANCE_IP}.nip.io" "http://${INSTANCE_IP}:${CLUSTER_NAME}80/get" -s -o /dev/null -w "%{http_code}")
+        http_code=$(curl -u ramiro:ramiro -H "Host: ${INSTANCE_IP//./-}.nip.io" "http://${INSTANCE_IP}:${CLUSTER_NAME}80/get" -s -o /dev/null -w "%{http_code}")
         if [ "${http_code}" -ne "401" ]; then return 1; fi
     }
     loop_it test 30 2
@@ -230,11 +178,10 @@ load ./helper
     [ "$status" -eq 0 ]
 }
 
-@test "Groups. Test no-auth secured httpbin ingress demo project (cloud)" {
+@test "Groups. Test no-auth secured httpbin ingress demo project" {
     info
-    if [ "${INSTANCE_IP}" == "localhost" ]; then skip "This test was designed to be run on cloud instances"; fi
     test(){
-        http_code=$(curl "http://httpbin.${INSTANCE_IP}.nip.io:${CLUSTER_NAME}80/get" -s -o /dev/null -w "%{http_code}")
+        http_code=$(curl -H "Host: ${INSTANCE_IP//./-}.nip.io" "http://${INSTANCE_IP}:${CLUSTER_NAME}80/get" -s -o /dev/null -w "%{http_code}")
         if [ "${http_code}" -ne "401" ]; then return 1; fi
     }
     loop_it test 30 2
@@ -242,23 +189,10 @@ load ./helper
     [ "$status" -eq 0 ]
 }
 
-@test "Groups. Test no-auth secured httpbin ingress demo project (local)" {
+@test "Groups. Test auth httpbin secured ingress demo project" {
     info
-    if [ "${INSTANCE_IP}" != "localhost" ]; then skip; fi
     test(){
-        http_code=$(curl -H "Host: httpbin.${INSTANCE_IP}.nip.io" "http://${INSTANCE_IP}:${CLUSTER_NAME}80/get" -s -o /dev/null -w "%{http_code}")
-        if [ "${http_code}" -ne "401" ]; then return 1; fi
-    }
-    loop_it test 30 2
-    status=${loop_it_result}
-    [ "$status" -eq 0 ]
-}
-
-@test "Groups. Test auth httpbin secured ingress demo project (cloud)" {
-    info
-    if [ "${INSTANCE_IP}" == "localhost" ]; then skip "This test was designed to be run on cloud instances"; fi
-    test(){
-        http_code=$(curl -u jacopo:admin "http://httpbin.${INSTANCE_IP}.nip.io:${CLUSTER_NAME}80/get" -s -o /dev/null -w "%{http_code}")
+        http_code=$(curl -u jacopo:admin -H "Host: ${INSTANCE_IP//./-}.nip.io" "http://${INSTANCE_IP}:${CLUSTER_NAME}80/get" -s -o /dev/null -w "%{http_code}")
         if [ "${http_code}" -ne "200" ]; then return 1; fi
     }
     loop_it test 30 2
@@ -266,36 +200,10 @@ load ./helper
     [ "$status" -eq 0 ]
 }
 
-@test "Groups. Test auth httpbin secured ingress demo project (local)" {
+@test "Groups. Test auth (no authorized) httpbin secured ingress demo project" {
     info
-    if [ "${INSTANCE_IP}" != "localhost" ]; then skip; fi
     test(){
-        http_code=$(curl -u jacopo:admin -H "Host: httpbin.${INSTANCE_IP}.nip.io" "http://${INSTANCE_IP}:${CLUSTER_NAME}80/get" -s -o /dev/null -w "%{http_code}")
-        if [ "${http_code}" -ne "200" ]; then return 1; fi
-    }
-    loop_it test 30 2
-    status=${loop_it_result}
-    [ "$status" -eq 0 ]
-}
-
-
-@test "Groups. Test auth (no authorized) httpbin secured ingress demo project (cloud)" {
-    info
-    if [ "${INSTANCE_IP}" == "localhost" ]; then skip "This test was designed to be run on cloud instances"; fi
-    test(){
-        http_code=$(curl -u angel:angel "http://httpbin.${INSTANCE_IP}.nip.io:${CLUSTER_NAME}80/get" -s -o /dev/null -w "%{http_code}")
-        if [ "${http_code}" -ne "401" ]; then return 1; fi
-    }
-    loop_it test 30 2
-    status=${loop_it_result}
-    [ "$status" -eq 0 ]
-}
-
-@test "Groups. Test auth (no authorized) httpbin secured ingress demo project (local)" {
-    info
-    if [ "${INSTANCE_IP}" != "localhost" ]; then skip; fi
-    test(){
-        http_code=$(curl -u angel:angel -H "Host: httpbin.${INSTANCE_IP}.nip.io" "http://${INSTANCE_IP}:${CLUSTER_NAME}80/get" -s -o /dev/null -w "%{http_code}")
+        http_code=$(curl -u angel:angel -H "Host: ${INSTANCE_IP//./-}.nip.io" "http://${INSTANCE_IP}:${CLUSTER_NAME}80/get" -s -o /dev/null -w "%{http_code}")
         if [ "${http_code}" -ne "401" ]; then return 1; fi
     }
     loop_it test 30 2

--- a/katalog/tests/nginx-ldap-auth/httpbin.yaml
+++ b/katalog/tests/nginx-ldap-auth/httpbin.yaml
@@ -47,7 +47,7 @@ spec:
         app: httpbin
     spec:
       containers:
-      - image: kennethreitz/httpbin
+      - image: reg.sighup.io/sighupio/fury/kennethreitz/httpbin:latest
         name: httpbin
         ports:
         - containerPort: 80

--- a/katalog/tests/nginx-ldap-auth/ldap-registry.yaml
+++ b/katalog/tests/nginx-ldap-auth/ldap-registry.yaml
@@ -63,7 +63,7 @@ spec:
         persistentVolumeClaim:
           claimName: registry
       containers:
-      - image: registry:2.7.1
+      - image: reg.sighup.io/sighupio/fury/registry:2.7.1
         name: registry
         ports:
         - containerPort: 5000

--- a/katalog/tests/nginx-ldap-auth/ldap-server.yaml
+++ b/katalog/tests/nginx-ldap-auth/ldap-server.yaml
@@ -62,7 +62,7 @@ spec:
           name: ldap-ldif
       containers:
       - name: ldap-server
-        image: osixia/openldap:1.3.0
+        image: reg.sighup.io/sighupio/fury/osixia/openldap:1.3.0
         command:
           - "sh"
           - "-c"

--- a/katalog/tests/tests.bats
+++ b/katalog/tests/tests.bats
@@ -21,8 +21,8 @@ wait_for_settlement (){
 
 @test "applying monitoring" {
   info
-  kubectl apply -f https://raw.githubusercontent.com/sighupio/fury-kubernetes-monitoring/v1.3.0/katalog/prometheus-operator/crd-servicemonitor.yml
-  kubectl apply -f https://raw.githubusercontent.com/sighupio/fury-kubernetes-monitoring/v1.3.0/katalog/prometheus-operator/crd-rule.yml
+  kubectl apply -f https://raw.githubusercontent.com/sighupio/fury-kubernetes-monitoring/v1.10.3/katalog/prometheus-operator/crd-servicemonitor.yml
+  kubectl apply -f https://raw.githubusercontent.com/sighupio/fury-kubernetes-monitoring/v1.10.3/katalog/prometheus-operator/crd-rule.yml
 }
 
 @test "testing dual-nginx apply" {


### PR DESCRIPTION
Ciao Team!

As you probable know, I'm starting to craft a new Fury release. It includes:

- Upgrade [cert-manager](../../katalog/cert-manager). From v1.0.1 to
[v1.1.0](https://github.com/jetstack/cert-manager/releases/tag/v1.1.0)
- Upgrade [nginx-ingress-controller](../../katalog/nginx) and its variants
(from v0.35.0 to [v0.42.0](https://github.com/kubernetes/ingress-nginx/releases/tag/controller-v0.42.0)):
  - [dual-nginx](../../katalog/dual-nginx)
  - [nginx-gke](../../katalog/nginx-gke)
  - [nginx-ovh](../../katalog/nginx-ovh)
- Upgrade [forecastle](../../katalog/forecastle). From 1.0.57 to
[1.0.61](https://github.com/stakater/Forecastle/releases/tag/v1.0.61)
- Kubernetes support:
  - Deprecate Kubernetes 1.16 support.
  - Kubernetes 1.19 is considered stable.
  - Add tech-preview support to Kubernete 1.20.

The upgrade procedure has been tested locally and documented in the releases notes.

Ping me if any doubt pop ups!