### PR TITLE
adding Pomerium as zero-trust proxy service

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -41,6 +41,7 @@ steps:
       - kustomize build katalog/forecastle > forecastle.yml
       - kustomize build katalog/nginx > nginx.yml
       - kustomize build katalog/nginx-ldap-auth > nginx-ldap-auth.yml
+      - kustomize build katalog/pomerium > pomerium.yml
 
   - &deprek8ion
     name: deprek8ion-cert-manager
@@ -72,6 +73,11 @@ steps:
     name: deprek8ion-nginx-ldap-auth
     environment:
       KUBERNETES_MANIFESTS: nginx-ldap-auth.yml
+
+  - <<: *deprek8ion
+    name: deprek8ion-pomerium
+    environment:
+      KUBERNETES_MANIFESTS: pomerium.yml
 ---
 kind: pipeline
 name: render-examples
@@ -93,7 +99,7 @@ steps:
   - name: examples
     image: quay.io/sighup/furyctl-bats:v0.1.3_3.2.2
     pull: always
-    depends_on: [ clone ]
+    depends_on: [clone]
     commands:
       - git config --global url."https://github.com/".insteadOf ssh://git@github.com
       - bats examples/tests.bats
@@ -119,9 +125,9 @@ steps:
     image: quay.io/sighup/e2e-testing-drone-plugin:v0.9.0
     pull: always
     volumes:
-    - name: shared
-      path: /shared
-    depends_on: [ clone ]
+      - name: shared
+        path: /shared
+    depends_on: [clone]
     settings:
       action: cluster-117
       pipeline_id: cluster-117
@@ -149,9 +155,9 @@ steps:
     image: quay.io/sighup/e2e-testing:1.1.0_0.2.2_2.16.1_1.4.0_1.17.11_3.3.0_2.4.1
     pull: always
     volumes:
-    - name: shared
-      path: /shared
-    depends_on: [ init ]
+      - name: shared
+        path: /shared
+    depends_on: [init]
     commands:
       - export CLUSTER_NAME=117
       - export INSTANCE_IP=$(cat /shared/machine/ip)
@@ -161,7 +167,7 @@ steps:
 
   - name: destroy
     image: quay.io/sighup/e2e-testing-drone-plugin:v0.9.0
-    depends_on: [ e2e ]
+    depends_on: [e2e]
     settings:
       action: destroy
       pipeline_id: cluster-117
@@ -185,12 +191,12 @@ steps:
         from_secret: dockerhub_password
     when:
       status:
-      - success
-      - failure
+        - success
+        - failure
 
 volumes:
-- name: shared
-  temp: {}
+  - name: shared
+    temp: {}
 
 ---
 kind: pipeline
@@ -213,9 +219,9 @@ steps:
     image: quay.io/sighup/e2e-testing-drone-plugin:v0.9.0
     pull: always
     volumes:
-    - name: shared
-      path: /shared
-    depends_on: [ clone ]
+      - name: shared
+        path: /shared
+    depends_on: [clone]
     settings:
       action: cluster-118
       pipeline_id: cluster-118
@@ -243,9 +249,9 @@ steps:
     image: quay.io/sighup/e2e-testing:1.1.0_0.2.2_2.16.1_1.4.0_1.18.8_3.3.0_2.4.1
     pull: always
     volumes:
-    - name: shared
-      path: /shared
-    depends_on: [ init ]
+      - name: shared
+        path: /shared
+    depends_on: [init]
     commands:
       - export CLUSTER_NAME=118
       - export INSTANCE_IP=$(cat /shared/machine/ip)
@@ -255,7 +261,7 @@ steps:
 
   - name: destroy
     image: quay.io/sighup/e2e-testing-drone-plugin:v0.9.0
-    depends_on: [ e2e ]
+    depends_on: [e2e]
     settings:
       action: destroy
       pipeline_id: cluster-118
@@ -279,12 +285,12 @@ steps:
         from_secret: dockerhub_password
     when:
       status:
-      - success
-      - failure
+        - success
+        - failure
 
 volumes:
-- name: shared
-  temp: {}
+  - name: shared
+    temp: {}
 
 ---
 kind: pipeline
@@ -307,9 +313,9 @@ steps:
     image: quay.io/sighup/e2e-testing-drone-plugin:v0.9.0
     pull: always
     volumes:
-    - name: shared
-      path: /shared
-    depends_on: [ clone ]
+      - name: shared
+        path: /shared
+    depends_on: [clone]
     settings:
       action: cluster-119
       pipeline_id: cluster-119
@@ -337,9 +343,9 @@ steps:
     image: quay.io/sighup/e2e-testing:1.1.0_0.2.2_2.16.1_1.4.0_1.19.4_3.3.0_2.4.1
     pull: always
     volumes:
-    - name: shared
-      path: /shared
-    depends_on: [ init ]
+      - name: shared
+        path: /shared
+    depends_on: [init]
     commands:
       - export CLUSTER_NAME=119
       - export INSTANCE_IP=$(cat /shared/machine/ip)
@@ -350,7 +356,7 @@ steps:
   - name: destroy
     image: quay.io/sighup/e2e-testing-drone-plugin:v0.9.0
     pull: always
-    depends_on: [ e2e ]
+    depends_on: [e2e]
     settings:
       action: destroy
       pipeline_id: cluster-119
@@ -374,12 +380,12 @@ steps:
         from_secret: dockerhub_password
     when:
       status:
-      - success
-      - failure
+        - success
+        - failure
 
 volumes:
-- name: shared
-  temp: {}
+  - name: shared
+    temp: {}
 
 ---
 kind: pipeline
@@ -402,9 +408,9 @@ steps:
     image: quay.io/sighup/e2e-testing-drone-plugin:v0.9.0
     pull: always
     volumes:
-    - name: shared
-      path: /shared
-    depends_on: [ clone ]
+      - name: shared
+        path: /shared
+    depends_on: [clone]
     settings:
       action: cluster-120
       pipeline_id: cluster-120
@@ -432,9 +438,9 @@ steps:
     image: quay.io/sighup/e2e-testing:1.1.0_0.2.2_2.16.1_1.4.0_1.20.0_3.3.0_2.4.1
     pull: always
     volumes:
-    - name: shared
-      path: /shared
-    depends_on: [ init ]
+      - name: shared
+        path: /shared
+    depends_on: [init]
     commands:
       - export CLUSTER_NAME=120
       - export INSTANCE_IP=$(cat /shared/machine/ip)
@@ -444,7 +450,7 @@ steps:
 
   - name: destroy
     image: quay.io/sighup/e2e-testing-drone-plugin:v0.9.0
-    depends_on: [ e2e ]
+    depends_on: [e2e]
     settings:
       action: destroy
       pipeline_id: cluster-120
@@ -468,12 +474,12 @@ steps:
         from_secret: dockerhub_password
     when:
       status:
-      - success
-      - failure
+        - success
+        - failure
 
 volumes:
-- name: shared
-  temp: {}
+  - name: shared
+    temp: {}
 
 ---
 kind: pipeline
@@ -497,7 +503,7 @@ steps:
   - name: prepare-tar-gz
     image: alpine:latest
     pull: always
-    depends_on: [ clone ]
+    depends_on: [clone]
     commands:
       - tar -zcvf fury-kubernetes-ingress-${DRONE_TAG}.tar.gz katalog/ LICENSE README.md
     when:
@@ -508,7 +514,7 @@ steps:
   - name: prepare-release-notes
     image: quay.io/sighup/fury-release-notes-plugin:3.7_2.8.4
     pull: always
-    depends_on: [ clone ]
+    depends_on: [clone]
     settings:
       release_notes_file_path: release-notes.md
     when:

--- a/README.md
+++ b/README.md
@@ -18,7 +18,9 @@ provides delivery services for Kubernetes applications. Version: **0.42.0**
 - [dual-nginx](katalog/dual-nginx): It deploys two identical NGINX ingress controllers
 but with two different scopes: public/external and private/internal. Version: **0.42.0**
 - [nginx-ldap-auth](katalog/nginx-ldap-auth): Use this to provide an ingress authentication over LDAP for
+Kubernetes. Version: **1.0.6**
 - [pomerium](katalog/pomerium): Use this to provide an ingress authentication over dex oidc auth. Version **0.13.2**
+  
 
 ## Compatibility
 

--- a/README.md
+++ b/README.md
@@ -18,8 +18,7 @@ provides delivery services for Kubernetes applications. Version: **0.42.0**
 - [dual-nginx](katalog/dual-nginx): It deploys two identical NGINX ingress controllers
 but with two different scopes: public/external and private/internal. Version: **0.42.0**
 - [nginx-ldap-auth](katalog/nginx-ldap-auth): Use this to provide an ingress authentication over LDAP for
-Kubernetes. Version: **1.0.6**
-
+- [pomerium](katalog/pomerium): Use this to provide an ingress authentication over dex oidc auth. Version **0.13.2**
 
 ## Compatibility
 

--- a/katalog/pomerium/README.md
+++ b/katalog/pomerium/README.md
@@ -49,8 +49,7 @@ Just copy the examples in the module and override them according to your setting
 
 ## Ingresses
 
-Once do that, Pomerium and Dex and correctly configured.
-The only missing step is to add annotations to the ingresses you've added previously in the policy yaml file:
+Once Pomerium and Dex are correctly configured, the last step is to add annotations to the ingresses you've added previously in the policy yaml file:
 
 ```yaml
 ---

--- a/katalog/pomerium/README.md
+++ b/katalog/pomerium/README.md
@@ -1,0 +1,82 @@
+# Pomerium Setup
+
+This document is intended to give a brief overview on how Pomerium can be implemented, for further details, please look at the official doc : https://www.pomerium.io/docs/
+
+## Setup
+
+the base kustomization component present [here](./kustomization.yaml) allows to quickly integrate this service with an existing Dex service that very likely is connected to an LDAP.
+
+For this reason you will need to edit your Dex configuration in order to add a static client for Pomerium service like in the example above:
+
+```yaml
+>>staticClients:
+    - id: "pomerium-auth-client"
+      secret: "your-super-secret"
+      name: "Pomerium"
+      redirectURIs:
+       - "https://pomerium.example.com/oauth2/callback"
+```
+
+setting the redirectURIs, accordingly with the host you used for the pomerium ingress.
+
+Once do that, you will need to use ovverride the configuration example ([policy](./config/policy.example.yaml) and environment variables as [configmap](./config/config.example.env) and [secret](secrets/pomerium.example.env)) like in the example above:
+
+```yaml
+configMapGenerator:
+    - name: pomerium-policy
+      behavior: replace
+      files:
+          - policy.yml=config/pomerium-policy.yml
+    - name: pomerium
+      behavior: replace
+      envs:
+          - config/pomerium-config.env
+
+secretGenerator:
+    - name: pomerium-env
+      behavior: replace
+      envs:
+          - secrets/pomerium.env
+```
+
+just copy the examples in the module and override them accordingly with your settings.
+
+**⚠ WARNING: in the policy file, you'll need to setup many policy as many ingress you want to protect under the pomerium authorization service.**
+
+## Ingresses
+
+Once do that, Pomerium and Dex and correctly configured.
+The only missing step is to add annotations to the ingresses you've added previously in the policy yaml file:
+
+```yaml
+---
+apiVersion: networking.k8s.io/v1beta1
+kind: Ingress
+metadata:
+    annotations:
+        forecastle.stakater.com/expose: "true"
+        forecastle.stakater.com/appName: "Prometheus"
+        forecastle.stakater.com/icon: "https://github.com/stakater/ForecastleIcons/raw/master/prometheus.png"
+        kubernetes.io/ingress.class: "internal"
+        kubernetes.io/tls-acme: "true"
+        # authentication annotations
+        nginx.ingress.kubernetes.io/auth-url: "https://pomerium.example.com/verify?uri=$scheme://$host$request_uri"
+        nginx.ingress.kubernetes.io/auth-signin: "https://pomerium.example.com/?uri=$scheme://$host$request_uri"
+    name: prometheus
+    namespace: monitoring
+spec:
+    rules:
+        - host: prometheus.example.com
+          http:
+              paths:
+                  - path: /
+                    backend:
+                        serviceName: prometheus-k8s
+                        servicePort: web
+    tls:
+        - hosts:
+              - prometheus.example.com
+          secretName: prometheus-tls
+```
+
+Now if you'll try to reach the `prometheus.example.com` you'll be forwarded to the dex login page accordingly with the rules set in your policy. Enjoy!

--- a/katalog/pomerium/README.md
+++ b/katalog/pomerium/README.md
@@ -8,7 +8,7 @@ This document is intended to give a brief overview on how Pomerium can be implem
 
 ## Setup
 
-the base kustomization component present [here](./kustomization.yaml) allows to quickly integrate this service with an existing Dex service that very likely is connected to an LDAP.
+The base kustomization file present [here](./kustomization.yaml) allows to quickly integrate this service with an existing Dex service, that could, for example, be connected to LDAP.
 
 In order to do so, you will need to edit your Dex configuration, adding a static client to be used by Pomerium, like in the example below:
 

--- a/katalog/pomerium/README.md
+++ b/katalog/pomerium/README.md
@@ -1,6 +1,6 @@
 # Pomerium Setup
 
-This document is intended to give a brief overview on how Pomerium can be implemented, for further details, please look at the official doc : https://www.pomerium.io/docs/
+This document is intended to give a brief overview on how Pomerium can be implemented, for further details, please look at the official doc : <https://www.pomerium.io/docs/>
 
 ## Setup
 
@@ -23,20 +23,20 @@ Once do that, you will need to use ovverride the configuration example ([policy]
 
 ```yaml
 configMapGenerator:
-    - name: pomerium-policy
-      behavior: replace
-      files:
-          - policy.yml=config/pomerium-policy.yml
-    - name: pomerium
-      behavior: replace
-      envs:
-          - config/pomerium-config.env
+  - name: pomerium-policy
+    behavior: replace
+    files:
+      - policy.yml=config/pomerium-policy.yml
+  - name: pomerium
+    behavior: replace
+    envs:
+      - config/pomerium-config.env
 
 secretGenerator:
-    - name: pomerium-env
-      behavior: replace
-      envs:
-          - secrets/pomerium.env
+  - name: pomerium-env
+    behavior: replace
+    envs:
+      - secrets/pomerium.env
 ```
 
 just copy the examples in the module and override them accordingly with your settings.
@@ -53,30 +53,30 @@ The only missing step is to add annotations to the ingresses you've added previo
 apiVersion: networking.k8s.io/v1beta1
 kind: Ingress
 metadata:
-    annotations:
-        forecastle.stakater.com/expose: "true"
-        forecastle.stakater.com/appName: "Prometheus"
-        forecastle.stakater.com/icon: "https://github.com/stakater/ForecastleIcons/raw/master/prometheus.png"
-        kubernetes.io/ingress.class: "internal"
-        kubernetes.io/tls-acme: "true"
-        # authentication annotations
-        nginx.ingress.kubernetes.io/auth-url: "https://pomerium.example.com/verify?uri=$scheme://$host$request_uri"
-        nginx.ingress.kubernetes.io/auth-signin: "https://pomerium.example.com/?uri=$scheme://$host$request_uri"
-    name: prometheus
-    namespace: monitoring
+  annotations:
+    forecastle.stakater.com/expose: "true"
+    forecastle.stakater.com/appName: "Prometheus"
+    forecastle.stakater.com/icon: "https://github.com/stakater/ForecastleIcons/raw/master/prometheus.png"
+    kubernetes.io/ingress.class: "internal"
+    kubernetes.io/tls-acme: "true"
+    # authentication annotations
+    nginx.ingress.kubernetes.io/auth-url: "https://pomerium.example.com/verify?uri=$scheme://$host$request_uri"
+    nginx.ingress.kubernetes.io/auth-signin: "https://pomerium.example.com/?uri=$scheme://$host$request_uri"
+  name: prometheus
+  namespace: monitoring
 spec:
-    rules:
-        - host: prometheus.example.com
-          http:
-              paths:
-                  - path: /
-                    backend:
-                        serviceName: prometheus-k8s
-                        servicePort: web
-    tls:
-        - hosts:
-              - prometheus.example.com
-          secretName: prometheus-tls
+  rules:
+    - host: prometheus.example.com
+      http:
+        paths:
+          - path: /
+            backend:
+              serviceName: prometheus-k8s
+              servicePort: web
+  tls:
+    - hosts:
+        - prometheus.example.com
+      secretName: prometheus-tls
 ```
 
 Now if you'll try to reach the `prometheus.example.com` you'll be forwarded to the dex login page accordingly with the rules set in your policy. Enjoy!

--- a/katalog/pomerium/README.md
+++ b/katalog/pomerium/README.md
@@ -21,7 +21,7 @@ In order to do so, you will need to edit your Dex configuration, adding a static
        - "https://pomerium.example.com/oauth2/callback"
 ```
 
-setting the redirectURIs, accordingly with the host you used for the pomerium ingress.
+Configure the `redirectURIs` section accordingly to the hosts used for the pomerium ingress.
 
 Once do that, you will need to use ovverride the configuration example ([policy](./config/policy.example.yaml) and environment variables as [configmap](./config/config.example.env) and [secret](secrets/pomerium.example.env)) like in the example above:
 

--- a/katalog/pomerium/README.md
+++ b/katalog/pomerium/README.md
@@ -43,7 +43,7 @@ secretGenerator:
       - secrets/pomerium.env
 ```
 
-just copy the examples in the module and override them accordingly with your settings.
+Just copy the examples in the module and override them according to your settings.
 
 **⚠ WARNING: in the policy file, you'll need to setup many policy as many ingress you want to protect under the pomerium authorization service.**
 

--- a/katalog/pomerium/README.md
+++ b/katalog/pomerium/README.md
@@ -10,7 +10,7 @@ This document is intended to give a brief overview on how Pomerium can be implem
 
 the base kustomization component present [here](./kustomization.yaml) allows to quickly integrate this service with an existing Dex service that very likely is connected to an LDAP.
 
-For this reason you will need to edit your Dex configuration in order to add a static client for Pomerium service like in the example above:
+In order to do so, you will need to edit your Dex configuration, adding a static client to be used by Pomerium, like in the example below:
 
 ```yaml
 >>staticClients:

--- a/katalog/pomerium/README.md
+++ b/katalog/pomerium/README.md
@@ -23,7 +23,7 @@ In order to do so, you will need to edit your Dex configuration, adding a static
 
 Configure the `redirectURIs` section accordingly to the hosts used for the pomerium ingress.
 
-Once do that, you will need to use ovverride the configuration example ([policy](./config/policy.example.yaml) and environment variables as [configmap](./config/config.example.env) and [secret](secrets/pomerium.example.env)) like in the example above:
+Once dex is configured correctly, you will need to ovverride the configuration example ([policy](./config/policy.example.yaml) and environment variables via a [configmap](./config/config.example.env) and [secret](secrets/pomerium.example.env)) like in the example below:
 
 ```yaml
 configMapGenerator:

--- a/katalog/pomerium/README.md
+++ b/katalog/pomerium/README.md
@@ -45,7 +45,7 @@ secretGenerator:
 
 Just copy the examples in the module and override them according to your settings.
 
-**⚠ WARNING: in the policy file, you'll need to setup many policy as many ingress you want to protect under the pomerium authorization service.**
+**⚠ WARNING: in the policy file, you'll need to set up a policy for each ingress you want to protect with Pomerium authorization service.**
 
 ## Ingresses
 

--- a/katalog/pomerium/README.md
+++ b/katalog/pomerium/README.md
@@ -1,4 +1,8 @@
-# Pomerium Setup
+# Pomerium
+
+Pomerium is an identity-aware proxy that enables secure access to internal applications. Pomerium provides a standardized interface to add access control to applications regardless of whether the application itself has authorization or authentication baked-in
+
+## Pomerium Setup
 
 This document is intended to give a brief overview on how Pomerium can be implemented, for further details, please look at the official doc : <https://www.pomerium.io/docs/>
 

--- a/katalog/pomerium/config/config.example.env
+++ b/katalog/pomerium/config/config.example.env
@@ -1,0 +1,12 @@
+FORWARD_AUTH_HOST=pomerium.example.com
+AUTHENTICATE_SERVICE_HOST=pomerium.example.com
+FORWARD_AUTH_URL=https://$(FORWARD_AUTH_HOST)
+AUTHENTICATE_SERVICE_URL=https://$(AUTHENTICATE_SERVICE_HOST)
+# See https://docs.pomerium.io/configuration/#identity-provider-name
+IDP_PROVIDER=oidc
+# IDP_PROVIDER_URL is the url of dex ingress
+IDP_PROVIDER_URL=https://dex.example.com/
+# IDP_CLIENT_ID is the name of the staticClient in Dex
+IDP_CLIENT_ID=pomerium-auth-client
+IDP_SCOPES=openid profile email offline_access groups
+# used by `ingress.yaml` by default.

--- a/katalog/pomerium/config/config.example.env
+++ b/katalog/pomerium/config/config.example.env
@@ -1,12 +1,12 @@
-FORWARD_AUTH_HOST=pomerium.example.com
 AUTHENTICATE_SERVICE_HOST=pomerium.example.com
-FORWARD_AUTH_URL=https://$(FORWARD_AUTH_HOST)
 AUTHENTICATE_SERVICE_URL=https://$(AUTHENTICATE_SERVICE_HOST)
+FORWARD_AUTH_HOST=pomerium.example.com
+FORWARD_AUTH_URL=https://$(FORWARD_AUTH_HOST)
+# IDP_CLIENT_ID is the name of the staticClient in Dex
+IDP_CLIENT_ID=pomerium-auth-client
 # See https://docs.pomerium.io/configuration/#identity-provider-name
 IDP_PROVIDER=oidc
 # IDP_PROVIDER_URL is the url of dex ingress
 IDP_PROVIDER_URL=https://dex.example.com/
-# IDP_CLIENT_ID is the name of the staticClient in Dex
-IDP_CLIENT_ID=pomerium-auth-client
 IDP_SCOPES=openid profile email offline_access groups
 # used by `ingress.yaml` by default.

--- a/katalog/pomerium/config/policy.example.yaml
+++ b/katalog/pomerium/config/policy.example.yaml
@@ -1,0 +1,17 @@
+address: ":8080"
+metrics_address: ":9090"
+grcp_address: ":8080"
+
+# this is set because the service is behind an ssl ingress
+insecure_server: true
+autocert: false
+
+policy:
+  # from and to should be set to the prometheus ingress
+  - from: https://prometheus.example.com
+    to: https://prometheus.example.com
+    allowed_idp_claims:
+      groups:
+        # ldap groups configured in dex
+        - group1
+        - group2

--- a/katalog/pomerium/config/policy.example.yaml
+++ b/katalog/pomerium/config/policy.example.yaml
@@ -1,3 +1,7 @@
+# Copyright (c) 2021 SIGHUP s.r.l All rights reserved.
+# Use of this source code is governed by a BSD-style
+# license that can be found in the LICENSE file.
+
 address: ":8080"
 metrics_address: ":9090"
 grcp_address: ":8080"

--- a/katalog/pomerium/deploy.yml
+++ b/katalog/pomerium/deploy.yml
@@ -1,3 +1,7 @@
+# Copyright (c) 2021 SIGHUP s.r.l All rights reserved.
+# Use of this source code is governed by a BSD-style
+# license that can be found in the LICENSE file.
+
 apiVersion: apps/v1
 kind: Deployment
 metadata:

--- a/katalog/pomerium/deploy.yml
+++ b/katalog/pomerium/deploy.yml
@@ -1,0 +1,65 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: pomerium
+
+spec:
+  replicas: 1
+  template:
+    spec:
+      containers:
+        - name: pomerium
+          image: pomerium/pomerium:v0.13.2
+          ports:
+            - containerPort: 443
+              name: https
+              protocol: TCP
+          args:
+            - -config
+            - /etc/pomerium/policy.yml
+          envFrom:
+            - secretRef:
+                name: pomerium-env
+            - configMapRef:
+                name: pomerium
+          env:
+            - name: SERVICES
+              value: all
+            - name: INSECURE_SERVER
+              value: "TRUE"
+            - name: JWT_CLAIMS_HEADERS
+              value: "email"
+            - name: LOG_LEVEL
+              value: "debug"
+            - name: PROXY_LOG_LEVEL
+              value: "debug"
+            - name: POMERIUM_DEBUG
+              value: "true"
+          livenessProbe:
+            failureThreshold: 3
+            httpGet:
+              path: /ping
+              port: 443
+              scheme: HTTP
+            initialDelaySeconds: 10
+            timeoutSeconds: 1
+          readinessProbe:
+            httpGet:
+              path: /ping
+              port: 443
+              scheme: HTTP
+          resources:
+            limits:
+              cpu: 500m
+              memory: 256Mi
+            requests:
+              cpu: 100m
+              memory: 128Mi
+          volumeMounts:
+            - mountPath: /etc/pomerium/
+              name: pomerium-policy
+      volumes:
+        - configMap:
+            defaultMode: 420
+            name: pomerium-policy
+          name: pomerium-policy

--- a/katalog/pomerium/deploy.yml
+++ b/katalog/pomerium/deploy.yml
@@ -15,8 +15,8 @@ spec:
         - name: pomerium
           image: pomerium/pomerium:v0.13.2
           ports:
-            - containerPort: 443
-              name: https
+            - containerPort: 8080
+              name: http
               protocol: TCP
           args:
             - -config
@@ -43,14 +43,14 @@ spec:
             failureThreshold: 3
             httpGet:
               path: /ping
-              port: 443
+              port: 8080
               scheme: HTTP
             initialDelaySeconds: 10
             timeoutSeconds: 1
           readinessProbe:
             httpGet:
               path: /ping
-              port: 443
+              port: 8080
               scheme: HTTP
           resources:
             limits:

--- a/katalog/pomerium/ingress.yml
+++ b/katalog/pomerium/ingress.yml
@@ -1,3 +1,7 @@
+# Copyright (c) 2021 SIGHUP s.r.l All rights reserved.
+# Use of this source code is governed by a BSD-style
+# license that can be found in the LICENSE file.
+
 apiVersion: extensions/v1beta1
 kind: Ingress
 metadata:

--- a/katalog/pomerium/ingress.yml
+++ b/katalog/pomerium/ingress.yml
@@ -1,0 +1,25 @@
+apiVersion: extensions/v1beta1
+kind: Ingress
+metadata:
+  name: pomerium
+  annotations:
+    kubernetes.io/ingress.class: "internal"
+    forecastle.stakater.com/expose: "true"
+    forecastle.stakater.com/appName: "Pomerium"
+    forecastle.stakater.com/icon: "https://pbs.twimg.com/profile_images/1161448498849390592/fJZaKEGR.png"
+    nginx.ingress.kubernetes.io/force-ssl-redirect: "true"
+    nginx.ingress.kubernetes.io/proxy-buffer-size: "16k"
+    kubernetes.io/tls-acme: "true"
+spec:
+  rules:
+    - host: $(AUTHENTICATE_SERVICE_HOST)
+      http:
+        paths:
+          - path: /
+            backend:
+              serviceName: pomerium
+              servicePort: 80
+  tls:
+    - hosts:
+        - $(AUTHENTICATE_SERVICE_HOST)
+      secretName: pomerium-tls

--- a/katalog/pomerium/kustomization.yaml
+++ b/katalog/pomerium/kustomization.yaml
@@ -1,3 +1,7 @@
+# Copyright (c) 2021 SIGHUP s.r.l All rights reserved.
+# Use of this source code is governed by a BSD-style
+# license that can be found in the LICENSE file.
+
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 

--- a/katalog/pomerium/kustomization.yaml
+++ b/katalog/pomerium/kustomization.yaml
@@ -1,0 +1,50 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+configurations:
+  - kustomize-config.yml
+
+commonLabels:
+  app: pomerium
+
+namespace: pomerium
+
+resources:
+  - namespace.yml
+  - deploy.yml
+  - svc.yml
+  - ingress.yml
+
+secretGenerator:
+  - name: pomerium-env
+    envs:
+      - secrets/pomerium.example.env
+
+configMapGenerator:
+  - name: pomerium-policy
+    files:
+      - config/policy.example.yaml
+  - name: pomerium
+    envs:
+      - config/config.example.env
+
+vars:
+  - name: AUTHENTICATE_SERVICE_HOST
+    objref:
+      kind: ConfigMap
+      name: pomerium
+      apiVersion: v1
+    fieldref:
+      fieldpath: data.AUTHENTICATE_SERVICE_HOST
+  - name: FORWARD_AUTH_HOST
+    objref:
+      kind: ConfigMap
+      name: pomerium
+      apiVersion: v1
+    fieldref:
+      fieldpath: data.FORWARD_AUTH_HOST
+
+images:
+  - name: pomerium/pomerium
+    newName: pomerium/pomerium
+    newTag: v0.13.2

--- a/katalog/pomerium/kustomize-config.yml
+++ b/katalog/pomerium/kustomize-config.yml
@@ -1,0 +1,3 @@
+varReference:
+  - path: data
+    kind: ConfigMap

--- a/katalog/pomerium/kustomize-config.yml
+++ b/katalog/pomerium/kustomize-config.yml
@@ -1,3 +1,7 @@
+# Copyright (c) 2021 SIGHUP s.r.l All rights reserved.
+# Use of this source code is governed by a BSD-style
+# license that can be found in the LICENSE file.
+
 varReference:
   - path: data
     kind: ConfigMap

--- a/katalog/pomerium/namespace.yml
+++ b/katalog/pomerium/namespace.yml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: pomerium

--- a/katalog/pomerium/namespace.yml
+++ b/katalog/pomerium/namespace.yml
@@ -1,3 +1,7 @@
+# Copyright (c) 2021 SIGHUP s.r.l All rights reserved.
+# Use of this source code is governed by a BSD-style
+# license that can be found in the LICENSE file.
+
 apiVersion: v1
 kind: Namespace
 metadata:

--- a/katalog/pomerium/secrets/pomerium.example.env
+++ b/katalog/pomerium/secrets/pomerium.example.env
@@ -1,0 +1,6 @@
+#IDP_CLIENT_SECRET is the secret configured in the pomerium Dex static client
+IDP_CLIENT_SECRET=super-secret-idp
+# COOKIE_SECRET is obtained with  `head -c32 /dev/urandom | base64` see https://www.pomerium.io/reference/#cookie-secret
+COOKIE_SECRET=super-secret-cookie
+# SHARED_SECRET is obtained with  `head -c32 /dev/urandom | base64` see https://www.pomerium.io/reference/#shared-secret
+SHARED_SECRET=super-secret-shared

--- a/katalog/pomerium/secrets/pomerium.example.env
+++ b/katalog/pomerium/secrets/pomerium.example.env
@@ -1,6 +1,6 @@
-#IDP_CLIENT_SECRET is the secret configured in the pomerium Dex static client
-IDP_CLIENT_SECRET=super-secret-idp
 # COOKIE_SECRET is obtained with  `head -c32 /dev/urandom | base64` see https://www.pomerium.io/reference/#cookie-secret
 COOKIE_SECRET=super-secret-cookie
+#IDP_CLIENT_SECRET is the secret configured in the pomerium Dex static client
+IDP_CLIENT_SECRET=super-secret-idp
 # SHARED_SECRET is obtained with  `head -c32 /dev/urandom | base64` see https://www.pomerium.io/reference/#shared-secret
 SHARED_SECRET=super-secret-shared

--- a/katalog/pomerium/svc.yml
+++ b/katalog/pomerium/svc.yml
@@ -1,3 +1,7 @@
+# Copyright (c) 2021 SIGHUP s.r.l All rights reserved.
+# Use of this source code is governed by a BSD-style
+# license that can be found in the LICENSE file.
+
 ---
 apiVersion: v1
 kind: Service

--- a/katalog/pomerium/svc.yml
+++ b/katalog/pomerium/svc.yml
@@ -1,0 +1,12 @@
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: pomerium
+spec:
+  ports:
+    - port: 80
+      name: http
+      targetPort: 8080
+
+


### PR DESCRIPTION
Hi everyone 👋 ,
with the special guest of @nikever  and @nutellinoit, I implemented the addition of pomerium as an authentication proxy behind services, in order to standardize the authentication method for services deployed in the cluster.
I am proposing the kustomize receipt, probably is missing something or can be better somehow.
I ask you to give it a look and suggest whatever you think to enhance it 👍 
