### PR TITLE
Add Nodeselector instructions to NGINX Readme

### DIFF
--- a/katalog/dual-nginx/README.md
+++ b/katalog/dual-nginx/README.md
@@ -35,6 +35,16 @@ If your cluster has `infra` nodes you should patch the daemonset adding the `Nod
 apiVersion: apps/v1
 kind: DaemonSet
 metadata:
+  name: nginx-ingress-external
+spec:
+  template:
+    spec:
+      nodeSelector:
+        node-kind.sighup.io/infra: ""
+---
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
   name: nginx-ingress-internal
 spec:
   template:

--- a/katalog/dual-nginx/README.md
+++ b/katalog/dual-nginx/README.md
@@ -35,7 +35,7 @@ If your cluster has `infra` nodes you should patch the daemonset adding the `Nod
 apiVersion: apps/v1
 kind: DaemonSet
 metadata:
-  name: nginx-ingress-external
+  name: nginx-ingress-controller-external
 spec:
   template:
     spec:
@@ -45,7 +45,7 @@ spec:
 apiVersion: apps/v1
 kind: DaemonSet
 metadata:
-  name: nginx-ingress-internal
+  name: nginx-ingress-controller-internal
 spec:
   template:
     spec:

--- a/katalog/dual-nginx/README.md
+++ b/katalog/dual-nginx/README.md
@@ -47,8 +47,6 @@ If you don't have infra nodes and you don't want to run ingress-controllers on a
 
 Finally, you can deploy NGINX by running the following command in the root of the project:
 
-You can deploy NGINX Double by running the following command in the root of the project:
-
 `$ kustomize build | kubectl apply -f -`
 
 ## Alerts

--- a/katalog/dual-nginx/README.md
+++ b/katalog/dual-nginx/README.md
@@ -24,6 +24,29 @@ Fury distribution Ingress NGINX Double is deployed with the following configurat
 
 ## Deployment
 
+Our Ingress module by default is deployed as a `DaemonSet`, meaning that it will try to deploy 1 ingress-controller pod on every worker node.
+
+This is probably NOT what you want, standard Fury clusters have at least 1 `infra` node (nodes that are dedicated to run Fury infrastructural components, like prometheus, elasticsearch, and the ingress controllers).
+
+If your cluster has `infra` nodes you should patch the daemonset adding the `NodeSelector` for the `infra` nodes to the Ingress `DaemonSet`. You can do this usiing the following kustomize patch:
+
+```yaml
+---
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: nginx-ingress-internal
+spec:
+  template:
+    spec:
+      nodeSelector:
+        node-kind.sighup.io/infra: ""
+```
+
+If you don't have infra nodes and you don't want to run ingress-controllers on all your worker nodes, you should probably label some nodes and adjust the previous `NodeSelector` accordingly.
+
+Finally, you can deploy NGINX by running the following command in the root of the project:
+
 You can deploy NGINX Double by running the following command in the root of the project:
 
 `$ kustomize build | kubectl apply -f -`

--- a/katalog/nginx-gke/README.md
+++ b/katalog/nginx-gke/README.md
@@ -24,6 +24,29 @@ Fury distribution NGINX GKE is deployed with following configuration:
 
 ## Deployment
 
+Our Ingress module by default is deployed as a `DaemonSet`, meaning that it will try to deploy 1 ingress-controller pod on every worker node.
+
+This is probably NOT what you want, standard Fury clusters have at least 1 `infra` node (nodes that are dedicated to run Fury infrastructural components, like prometheus, elasticsearch, and the ingress controllers).
+
+If your cluster has `infra` nodes you should patch the daemonset adding the `NodeSelector` for the `infra` nodes to the Ingress `DaemonSet`. You can do this usiing the following kustomize patch:
+
+```yaml
+---
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: nginx-ingress-internal
+spec:
+  template:
+    spec:
+      nodeSelector:
+        node-kind.sighup.io/infra: ""
+```
+
+If you don't have infra nodes and you don't want to run ingress-controllers on all your worker nodes, you should probably label some nodes and adjust the previous `NodeSelector` accordingly.
+
+Finally, you can deploy NGINX by running the following command in the root of the project:
+
 You can deploy NGINX GKE by running following command in the root of the project:
 
 `$ kustomize build | kubectl apply -f -`

--- a/katalog/nginx-gke/README.md
+++ b/katalog/nginx-gke/README.md
@@ -47,8 +47,6 @@ If you don't have infra nodes and you don't want to run ingress-controllers on a
 
 Finally, you can deploy NGINX by running the following command in the root of the project:
 
-You can deploy NGINX GKE by running following command in the root of the project:
-
 `$ kustomize build | kubectl apply -f -`
 
 

--- a/katalog/nginx-gke/README.md
+++ b/katalog/nginx-gke/README.md
@@ -35,7 +35,7 @@ If your cluster has `infra` nodes you should patch the daemonset adding the `Nod
 apiVersion: apps/v1
 kind: DaemonSet
 metadata:
-  name: nginx-ingress-internal
+  name: nginx-ingress-controller
 spec:
   template:
     spec:

--- a/katalog/nginx-ovh/README.md
+++ b/katalog/nginx-ovh/README.md
@@ -48,8 +48,6 @@ If you don't have infra nodes and you don't want to run ingress-controllers on a
 
 Finally, you can deploy NGINX by running the following command in the root of the project:
 
-You can deploy NGINX OVH by running the following command in the root of the project:
-
 `$ kustomize build | kubectl apply -f -`
 
 

--- a/katalog/nginx-ovh/README.md
+++ b/katalog/nginx-ovh/README.md
@@ -25,6 +25,29 @@ Fury distribution NGINX OVH is deployed with the following configuration:
 
 ## Deployment
 
+Our Ingress module by default is deployed as a `DaemonSet`, meaning that it will try to deploy 1 ingress-controller pod on every worker node.
+
+This is probably NOT what you want, standard Fury clusters have at least 1 `infra` node (nodes that are dedicated to run Fury infrastructural components, like prometheus, elasticsearch, and the ingress controllers).
+
+If your cluster has `infra` nodes you should patch the daemonset adding the `NodeSelector` for the `infra` nodes to the Ingress `DaemonSet`. You can do this usiing the following kustomize patch:
+
+```yaml
+---
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: nginx-ingress-internal
+spec:
+  template:
+    spec:
+      nodeSelector:
+        node-kind.sighup.io/infra: ""
+```
+
+If you don't have infra nodes and you don't want to run ingress-controllers on all your worker nodes, you should probably label some nodes and adjust the previous `NodeSelector` accordingly.
+
+Finally, you can deploy NGINX by running the following command in the root of the project:
+
 You can deploy NGINX OVH by running the following command in the root of the project:
 
 `$ kustomize build | kubectl apply -f -`

--- a/katalog/nginx-ovh/README.md
+++ b/katalog/nginx-ovh/README.md
@@ -36,7 +36,7 @@ If your cluster has `infra` nodes you should patch the daemonset adding the `Nod
 apiVersion: apps/v1
 kind: DaemonSet
 metadata:
-  name: nginx-ingress-internal
+  name: nginx-ingress-controller
 spec:
   template:
     spec:

--- a/katalog/nginx/README.md
+++ b/katalog/nginx/README.md
@@ -24,7 +24,28 @@ Fury distribution Ingress NGINX is deployed with the following configuration:
 
 ## Deployment
 
-You can deploy NGINX by running the following command in the root of the project:
+Our Ingress module by default is deployed as a `DaemonSet`, meaning that it will try to deploy 1 ingress-controller pod on every worker node.
+
+This is probably NOT what you want, standard Fury clusters have at least 1 `infra` node (nodes that are dedicated to run Fury infrastructural components, like prometheus, elasticsearch, and the ingress controllers).
+
+If your cluster has `infra` nodes you should patch the daemonset adding the `NodeSelector` for the `infra` nodes to the Ingress `DaemonSet`. You can do this usiing the following kustomize patch:
+
+```yaml
+---
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: nginx-ingress-internal
+spec:
+  template:
+    spec:
+      nodeSelector:
+        node-kind.sighup.io/infra: ""
+```
+
+If you don't have infra nodes and you don't want to run ingress-controllers on all your worker nodes, you should probably label some nodes and adjust the previous `NodeSelector` accordingly.
+
+Finally, you can deploy NGINX by running the following command in the root of the project:
 
 `$ kustomize build | kubectl apply -f -`
 

--- a/katalog/nginx/README.md
+++ b/katalog/nginx/README.md
@@ -35,7 +35,7 @@ If your cluster has `infra` nodes you should patch the daemonset adding the `Nod
 apiVersion: apps/v1
 kind: DaemonSet
 metadata:
-  name: nginx-ingress-internal
+  name: nginx-ingress-controller
 spec:
   template:
     spec:


### PR DESCRIPTION
This PR adds a warning on the deployment instructions for NGINX Ingress Controller about the NodeSelector that should be added to the default DaemonSet.