### PR TITLE
Fixed small typo in nginx-ovh

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ Kubernetes Fury Ingress provides the following packages:
 |--------------------------------------------|-----------|-------------------------------------------------------------------------------------------------------------------------------|
 | [nginx](katalog/nginx)                     | `v1.1.0`  | The NGINX Ingress Controller for Kubernetes provides delivery services for Kubernetes applications.                           |
 | [nginx-gke](katalog/nginx-gke)             | `v1.1.0`  | The same as `nginx`, but uses the native GKE LoadBalancer to expose the Ingress Controller to the Internet.                   |
-| [nginx-gke](katalog/nginx-ovh)             | `v1.1.0`  | The same as `nginx`, but uses the native OVH LoadBalancer to expose the Ingress Controller to the Internet.                   |
+| [nginx-ovh](katalog/nginx-ovh)             | `v1.1.0`  | The same as `nginx`, but uses the native OVH LoadBalancer to expose the Ingress Controller to the Internet.                   |
 | [dual-nginx](katalog/dual-nginx)           | `v1.1.0`  | It deploys two identical NGINX ingress controllers but with two different scopes: public/external and private/internal.       |
 | [cert-manager](katalog/cert-manager)       | `v1.6.1`  | cert-manager is a Kubernetes add-on to automate the management and issuance of TLS certificates from various issuing sources. |
 | [forecastle](katalog/forecastle)           | `v1.0.75` | Forecastle gives you access to a control panel where you can see your ingresses and access them on Kubernetes.                |


### PR DESCRIPTION
As title says, this just fixes a small typo on `nginx-ovh` link.