### PR TITLE
[DOCS] - Update READMEs with the upcoming furyctl v1.0.0 version

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,7 +147,7 @@ bases:
 
 > See `furyctl` [documentation][furyctl-repo] for additional details about `Furyfile.yml` format.
 
-2. Execute `furyctl vendor -H` to download the packages
+2. Execute `furyctl distribution download -H` to download the packages
 
 3. Inspect the download packages under `./vendor/katalog/ingress/`.
 
@@ -222,7 +222,7 @@ bases:
     version: "v1.12.2"
 ```
 
-2. Execute `furyctl vendor -H` to download the packages
+2. Execute `furyctl distribution download -H` to download the packages
 
 3. Inspect the download packages under `./vendor/katalog/ingress/cert-manager`.
 
@@ -287,7 +287,7 @@ bases:
     version: "v1.12.2"
 ```
 
-2. Execute `furyctl vendor -H` to download the packages
+2. Execute `furyctl distribution download -H` to download the packages
 
 3. Inspect the download packages under `./vendor/katalog/ingress/forecastle`.
 

--- a/katalog/cert-manager/README.md
+++ b/katalog/cert-manager/README.md
@@ -39,7 +39,7 @@ resources:
     version: "v1.12.2"
 ```
 
-2. Execute `furyctl vendor -H` to download the packages
+2. Execute `furyctl distribution download -H` to download the packages
 
 3. Inspect the download packages under `./vendor/katalog/ingress/cert-manager`.
 

--- a/katalog/dual-nginx/README.md
+++ b/katalog/dual-nginx/README.md
@@ -38,7 +38,7 @@ bases:
 
 > See `furyctl` [documentation][furyctl-repo] for additional details about `Furyfile.yml` format.
 
-2. Execute `furyctl vendor -H` to download the packages
+2. Execute `furyctl distribution download -H` to download the packages
 
 3. Inspect the download packages under `./vendor/katalog/ingress/dual-nginx`.
 

--- a/katalog/nginx-gke/README.md
+++ b/katalog/nginx-gke/README.md
@@ -36,7 +36,7 @@ bases:
 
 > See `furyctl` [documentation][furyctl-repo] for additional details about `Furyfile.yml` format.
 
-2. Execute `furyctl vendor -H` to download the packages
+2. Execute `furyctl distribution download -H` to download the packages
 
 3. Inspect the download packages under `./vendor/katalog/ingress/dual-nginx`.
 

--- a/katalog/nginx-ovh/README.md
+++ b/katalog/nginx-ovh/README.md
@@ -36,7 +36,7 @@ bases:
 
 > See `furyctl` [documentation][furyctl-repo] for additional details about `Furyfile.yml` format.
 
-2. Execute `furyctl vendor -H` to download the packages
+2. Execute `furyctl distribution download -H` to download the packages
 
 3. Inspect the download packages under `./vendor/katalog/ingress/dual-nginx`.
 

--- a/katalog/nginx/README.md
+++ b/katalog/nginx/README.md
@@ -34,7 +34,7 @@ bases:
 
 > See `furyctl` [documentation][furyctl-repo] for additional details about `Furyfile.yml` format.
 
-2. Execute `furyctl vendor -H` to download the packages
+2. Execute `furyctl distribution download -H` to download the packages
 
 3. Inspect the download packages under `./vendor/katalog/ingress/dual-nginx`.
 


### PR DESCRIPTION
As per title, updating furyctl reference to use the new command structure of the upcoming v1.0.0 version