### PR TITLE
fix(cert-manager): missing permission for leader-election

### DIFF
--- a/katalog/cert-manager/MAINTENANCE.md
+++ b/katalog/cert-manager/MAINTENANCE.md
@@ -17,6 +17,18 @@ And here you can find instructions on how to verify that the installation is OK:
 or you can use this tool also:
 <https://github.com/alenkacz/cert-manager-verifier>
 
+## Customizations
+
+Upstream cert-manager uses the `kube-system` namespace for the leader election lock. We are deploying everything, including the leader election lock, in the `cert-manager` namespace.
+
+We needed to add a custom snippet to the RBAC in version 1.13.0 of the module that was not included (or was deleted) in upstream.
+
+References:
+
+- <https://github.com/sighupio/fury-kubernetes-ingress/issues/91>
+- <https://github.com/cert-manager/cert-manager/issues/5471>
+- <https://github.com/cert-manager/cert-manager/issues/4102>
+
 ## Update guide
 
 1. Download upstream manifests:

--- a/katalog/cert-manager/cainjector/rbac.yml
+++ b/katalog/cert-manager/cainjector/rbac.yml
@@ -66,6 +66,10 @@ rules:
   - apiGroups: ["coordination.k8s.io"]
     resources: ["leases"]
     verbs: ["create"]
+  # SIGHUP custom - needed because we deploy everything in the cert-manager namespace
+  - apiGroups: [""]
+    resources: ["configmaps"]
+    verbs: ["get"]
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding

--- a/katalog/cert-manager/cert-manager-controller/rbac.yml
+++ b/katalog/cert-manager/cert-manager-controller/rbac.yml
@@ -379,6 +379,10 @@ rules:
   - apiGroups: ["coordination.k8s.io"]
     resources: ["leases"]
     verbs: ["create"]
+  # SIGHUP custom - needed because we deploy everything in the cert-manager namespace
+  - apiGroups: [""]
+    resources: ["configmaps"]
+    verbs: ["get"]
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding


### PR DESCRIPTION
Add RBAC permissions for get configmaps so the leader election can work in the cert-manager namespace.

Upstream doesn't need this permissions because they use `kube-system` namespace for leader election.

fixes #91