### PR TITLE
fix(cert-manager)!: align labels with upstream

### DIFF
--- a/katalog/cert-manager/cainjector/deploy.yml
+++ b/katalog/cert-manager/cainjector/deploy.yml
@@ -6,14 +6,27 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: cert-manager-cainjector
-  labels: {}
+  labels:
+    app: cainjector
+    app.kubernetes.io/name: cainjector
+    app.kubernetes.io/instance: cert-manager
+    app.kubernetes.io/component: "cainjector"
+    app.kubernetes.io/version: "v1.10.0"
 spec:
   replicas: 1
   selector:
-    matchLabels: {}
+    matchLabels:
+      app.kubernetes.io/name: cainjector
+      app.kubernetes.io/instance: cert-manager
+      app.kubernetes.io/component: "cainjector"
   template:
     metadata:
-      labels: {}
+      labels:
+        app: cainjector
+        app.kubernetes.io/name: cainjector
+        app.kubernetes.io/instance: cert-manager
+        app.kubernetes.io/component: "cainjector"
+        app.kubernetes.io/version: "v1.10.0"
     spec:
       serviceAccountName: cert-manager-cainjector
       securityContext:

--- a/katalog/cert-manager/cert-manager-controller/deploy.yml
+++ b/katalog/cert-manager/cert-manager-controller/deploy.yml
@@ -7,14 +7,27 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: cert-manager
-  labels: {}
+  labels:
+    app: cert-manager
+    app.kubernetes.io/name: cert-manager
+    app.kubernetes.io/instance: cert-manager
+    app.kubernetes.io/component: "controller"
+    app.kubernetes.io/version: "v1.10.0"
 spec:
   replicas: 1
   selector:
-    matchLabels: {}
+    matchLabels:
+      app.kubernetes.io/name: cert-manager
+      app.kubernetes.io/instance: cert-manager
+      app.kubernetes.io/component: "controller"
   template:
     metadata:
-      labels: {}
+      labels:
+        app: cert-manager
+        app.kubernetes.io/name: cert-manager
+        app.kubernetes.io/instance: cert-manager
+        app.kubernetes.io/component: "controller"
+        app.kubernetes.io/version: "v1.10.0"
       annotations:
         prometheus.io/path: "/metrics"
         prometheus.io/scrape: 'true'
@@ -60,7 +73,12 @@ apiVersion: v1
 kind: Service
 metadata:
   name: cert-manager
-  labels: {}
+  labels:
+    app: cert-manager
+    app.kubernetes.io/name: cert-manager
+    app.kubernetes.io/instance: cert-manager
+    app.kubernetes.io/component: "controller"
+    app.kubernetes.io/version: "v1.10.0"
 spec:
   type: ClusterIP
   ports:
@@ -68,4 +86,7 @@ spec:
     port: 9402
     name: tcp-prometheus-servicemonitor
     targetPort: 9402
-  selector: {}
+  selector:
+    app.kubernetes.io/name: cert-manager
+    app.kubernetes.io/instance: cert-manager
+    app.kubernetes.io/component: "controller"

--- a/katalog/cert-manager/cert-manager-controller/sm.yml
+++ b/katalog/cert-manager/cert-manager-controller/sm.yml
@@ -19,3 +19,6 @@ spec:
   selector:
     matchLabels:
       app: cert-manager
+      app.kubernetes.io/name: cert-manager
+      app.kubernetes.io/instance: cert-manager
+      app.kubernetes.io/component: "controller"

--- a/katalog/cert-manager/kustomization.yaml
+++ b/katalog/cert-manager/kustomization.yaml
@@ -11,6 +11,3 @@ resources:
   - cert-manager-controller
   - webhook
   - dashboards
-
-commonLabels:
-  app: cert-manager

--- a/katalog/cert-manager/webhook/deploy.yml
+++ b/katalog/cert-manager/webhook/deploy.yml
@@ -7,14 +7,27 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: cert-manager-webhook
-  labels: {}
+  labels:
+    app: webhook
+    app.kubernetes.io/name: webhook
+    app.kubernetes.io/instance: cert-manager
+    app.kubernetes.io/component: "webhook"
+    app.kubernetes.io/version: "v1.10.0"
 spec:
   replicas: 1
   selector:
-    matchLabels: {}
+    matchLabels:
+      app.kubernetes.io/name: webhook
+      app.kubernetes.io/instance: cert-manager
+      app.kubernetes.io/component: "webhook"
   template:
     metadata:
-      labels: {}
+      labels:
+        app: webhook
+        app.kubernetes.io/name: webhook
+        app.kubernetes.io/instance: cert-manager
+        app.kubernetes.io/component: "webhook"
+        app.kubernetes.io/version: "v1.10.0"
     spec:
       serviceAccountName: cert-manager-webhook
       securityContext:
@@ -82,11 +95,20 @@ apiVersion: v1
 kind: Service
 metadata:
   name: cert-manager-webhook
-  labels: {}
+  labels:
+    app: webhook
+    app.kubernetes.io/name: webhook
+    app.kubernetes.io/instance: cert-manager
+    app.kubernetes.io/component: "webhook"
+    app.kubernetes.io/version: "v1.10.0"
 spec:
+  type: ClusterIP
   ports:
   - name: https
     port: 443
     protocol: TCP
     targetPort: "https"
-  selector: {}
+  selector:
+    app.kubernetes.io/name: webhook
+    app.kubernetes.io/instance: cert-manager
+    app.kubernetes.io/component: "webhook"


### PR DESCRIPTION
stop using app=cert-manager as unique label for all deployments and start using the same labels as upstream.

fixes #90

BREAKING: changes to immutable fields. You need to delete cert-manager, cert-manager-webhook and cert-manager-cainjector deployments before applying.