### PR TITLE
feat(forecastle): update to version v1.0.119 and add crd

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,1 @@
 vendor
-delete-me

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 vendor
+delete-me

--- a/katalog/forecastle/README.md
+++ b/katalog/forecastle/README.md
@@ -39,6 +39,47 @@ Once deployed, to have an ingress show up in the dashboard provided by Forecastl
 ```shell
 kubectl annotate ingress <YOUR_INGRESS> "forecastle.stakater.com/expose=true" --overwrite
 ```
+#### ForecastleApp CRD
+
+You can now create custom resources to add apps to forecastle dynamically. This decouples the application configuration from Ingresses as well as forecastle config. You can create the custom resource `ForecastleApp` like the following:
+
+```yaml
+apiVersion: forecastle.stakater.com/v1alpha1
+kind: ForecastleApp
+metadata:
+  name: app-name
+spec:
+  name: My Awesome App
+  group: dev
+  icon: https://icon-url
+  url: http://app-url
+  networkRestricted: "false"
+  properties:
+    Version: 1.0
+  instance: "" # Optional
+```
+
+##### Automatically discover URL's from Kubernetes Resources
+
+Forecastle supports discovering URL's ForecastleApp CRD from the following resources:
+
+- Ingress
+
+The above type of resource that you want to discover URL from **MUST** exist in the same namespace as `ForecastleApp` CR. Then you can add the following to the CR:
+
+```yaml
+apiVersion: forecastle.stakater.com/v1alpha1
+kind: ForecastleApp
+metadata:
+  name: app-name
+spec:
+  name: My Awesome App
+  group: dev
+  icon: https://icon-url
+  urlFrom: # This is new
+    ingressRef:
+      name: my-app-ingress
+```
 
 ## Important notes
 

--- a/katalog/forecastle/README.md
+++ b/katalog/forecastle/README.md
@@ -11,7 +11,7 @@
 
 ## Image repository and tag
 
-- Forecastle image: `docker.io/stakater/forecastle:v1.0.103`
+- Forecastle image: `docker.io/stakater/forecastle:v1.0.119`
 - Forecastle repo: [https://github.com/stakater/Forecastle](https://github.com/stakater/Forecastle)
 
 ## Configuration

--- a/katalog/forecastle/config.yaml
+++ b/katalog/forecastle/config.yaml
@@ -5,7 +5,7 @@
 ---
 namespaceSelector:
   any: true
-crdEnabled: false
+crdEnabled: true
 customApps: {}
 instanceName: null
 title: "Kubernetes Fury Distribution - Applications Directory"

--- a/katalog/forecastle/crd.yml
+++ b/katalog/forecastle/crd.yml
@@ -1,0 +1,86 @@
+# Copyright (c) 2017-present SIGHUP s.r.l All rights reserved.
+# Use of this source code is governed by a BSD-style
+# license that can be found in the LICENSE file.
+
+---
+# Source: crds/forecastleApp.yaml
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: forecastleapps.forecastle.stakater.com
+spec:
+  conversion:
+    strategy: None
+  group: forecastle.stakater.com
+  names:
+    kind: ForecastleApp
+    listKind: ForecastleAppList
+    plural: forecastleapps
+    singular: forecastleapp
+  preserveUnknownFields: false
+  scope: Namespaced
+  versions:
+  - name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        type: object
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            properties:
+              group:
+                type: string
+              icon:
+                type: string
+              instance:
+                type: string
+              name:
+                type: string
+              networkRestricted:
+                type: boolean
+              properties:
+                additionalProperties:
+                  type: string
+                type: object
+              url:
+                type: string
+              urlFrom:
+                properties:
+                  ingressRef:
+                    type: object
+                    properties:
+                      name:
+                        type: string
+                  routeRef:
+                    type: object
+                    properties:
+                      name:
+                        type: string
+                  ingressRouteRef:
+                    type: object
+                    properties:
+                      name:
+                        type: string
+                type: object
+            required:
+            - name
+            - group
+            - icon
+            type: object
+          status:
+            type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}

--- a/katalog/forecastle/deploy.yml
+++ b/katalog/forecastle/deploy.yml
@@ -27,7 +27,7 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: metadata.namespace
-          image: "stakater/forecastle:v1.0.103"
+          image: "stakater/forecastle:v1.0.119"
           name: forecastle
           livenessProbe:
             httpGet:

--- a/katalog/forecastle/kustomization.yaml
+++ b/katalog/forecastle/kustomization.yaml
@@ -12,6 +12,7 @@ resources:
   - deploy.yml
   - rbac.yml
   - service.yml
+  - crd.yml
 
 images:
   - name: stakater/forecastle


### PR DESCRIPTION
fixes #99


### Bug Fixes

* **forecastle:** enable crds for the controller ([45cf498](https://github.com/sighupio/fury-kubernetes-ingress/commit/45cf498f3cae5ad6f21adc6d5b1b3bb7d9125bac))


### Features

* **forecastle:** update to version v1.0.119 and add crd ([3cfbb62](https://github.com/sighupio/fury-kubernetes-ingress/commit/3cfbb623ec233cda7a3538550e836fbad8d10dcc))


add the possibility of adding elements to the forecastle catalog using CustomResources was enabled, for this it was necessary to add the CustomResourceDefinition and allow this possibility in the controller configuration. 

soruce: https://github.com/stakater/Forecastle
