### PR TITLE
feat: put dashboards in "Ingress" grafana folder

### DIFF
--- a/katalog/cert-manager/dashboards/kustomization.yaml
+++ b/katalog/cert-manager/dashboards/kustomization.yaml
@@ -11,6 +11,8 @@ namespace: cert-manager
 generatorOptions:
   labels:
     grafana-sighup-dashboard: default
+  annotations:
+    grafana-folder: "Ingress"
   disableNameSuffixHash: true
 
 configMapGenerator:

--- a/katalog/nginx/bases/configs/dashboards/kustomization.yaml
+++ b/katalog/nginx/bases/configs/dashboards/kustomization.yaml
@@ -11,6 +11,8 @@ namespace: ingress-nginx
 generatorOptions:
   labels:
     grafana-sighup-dashboard: default
+  annotations:
+    grafana-folder: "Ingress"
   disableNameSuffixHash: true
 
 configMapGenerator:


### PR DESCRIPTION
Add annotation to put the module's Grafana dashboards inside the "Ingress" folder for better organization.