### PR TITLE
feat(external-dns): update image and add maintenance guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ Kubernetes Fury Ingress provides the following packages:
 | [nginx](katalog/nginx)                        | `v1.5.1`   | The NGINX Ingress Controller for Kubernetes provides delivery services for Kubernetes applications.                           |
 | [dual-nginx](katalog/dual-nginx)              | `v1.5.1`   | It deploys two identical NGINX ingress controllers but with two different scopes: public/external and private/internal.       |
 | [cert-manager](katalog/cert-manager)          | `v1.11.0`  | cert-manager is a Kubernetes add-on to automate the management and issuance of TLS certificates from various issuing sources. |
-| [external-dns](katalog/external-dns)          | `v0.13.2`  | external-dns allows you to manage DNS records natively from Kubernetes.                                                       |
+| [external-dns](katalog/external-dns)          | `v0.13.4`  | external-dns allows you to manage DNS records natively from Kubernetes.                                                       |
 | [forecastle](katalog/forecastle)              | `v1.0.119` | Forecastle gives you access to a control panel where you can see your ingresses and access them on Kubernetes.                |
 | [aws-cert-manager](modules/aws-cert-manager/) | -          | Terraform modules for managing IAM permissions on AWS for cert-manager                                                        |
 | [aws-external-dns](modules/aws-external-dns/) | -          | Terraform modules for managing IAM permissions on AWS for external-dns                                                        |

--- a/katalog/external-dns/MAINTENANCE.md
+++ b/katalog/external-dns/MAINTENANCE.md
@@ -5,7 +5,7 @@ To update External-DNS, follow these steps:
 1. Compare the manifests with upstream and port the required modifications.
 
    External-DNS manifests are taken from upstream from the following URL:
-   https://github.com/kubernetes-sigs/external-dns/tree/master/kustomize
+   <https://github.com/kubernetes-sigs/external-dns/tree/master/kustomize>
 
 2. Update the image tags and sync them to our registry.
 

--- a/katalog/external-dns/MAINTENANCE.md
+++ b/katalog/external-dns/MAINTENANCE.md
@@ -1,0 +1,19 @@
+# External-DNS Package Maintenance Guide
+
+To update External-DNS, follow these steps:
+
+1. Compare the manifests with upstream and port the required modifications.
+
+   External-DNS manifests are taken from upstream from the following URL:
+   https://github.com/kubernetes-sigs/external-dns/tree/master/kustomize
+
+2. Update the image tags and sync them to our registry.
+
+## Customizations
+
+- The External-DNS deployment has been adjusted to include certain security features such as:
+  - Changing the user that the image runs as
+  - Setting the UIDs
+  - Adding liveness and readiness probes
+
+It's crucial to pay careful attention to changes in RBACs or any variation in the deployment. Additionally, thoroughly review any breaking changes indicated by the provider.

--- a/katalog/external-dns/base/deploy.yml
+++ b/katalog/external-dns/base/deploy.yml
@@ -21,7 +21,7 @@ spec:
       serviceAccountName: external-dns
       containers:
       - name: external-dns
-        image: k8s.gcr.io/external-dns/external-dns:v0.13.2
+        image: k8s.gcr.io/external-dns/external-dns:v0.13.4
         args:
         - --source=service
         - --source=ingress


### PR DESCRIPTION
commit message:

Updated External DNS Image: Enhanced EKS support & added `eu-central-2` region

- Updated the external DNS image version which now works well in EKS environments. Local testing wasn't possible but cloud testing was successful.
- Added support for the `eu-central-2` region.
- Created a basic guide for project maintenance, see `MAINTENANCE.md` for details.

Please test this update in your local environment and provide feedback.