### PR TITLE
Feature/forecastle version bump 1.0.136

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ Kubernetes Fury Ingress provides the following packages:
 | [dual-nginx](katalog/dual-nginx)              | `v1.9.4`   | It deploys two identical NGINX ingress controllers but with two different scopes: public/external and private/internal.       |
 | [cert-manager](katalog/cert-manager)          | `v1.13.1`  | cert-manager is a Kubernetes add-on to automate the management and issuance of TLS certificates from various issuing sources. |
 | [external-dns](katalog/external-dns)          | `v0.13.6`  | external-dns allows you to manage DNS records natively from Kubernetes.                                                       |
-| [forecastle](katalog/forecastle)              | `v1.0.131` | Forecastle gives you access to a control panel where you can see your ingresses and access them on Kubernetes.                |
+| [forecastle](katalog/forecastle)              | `v1.0.136` | Forecastle gives you access to a control panel where you can see your ingresses and access them on Kubernetes.                |
 | [aws-cert-manager](modules/aws-cert-manager/) | -          | Terraform modules for managing IAM permissions on AWS for cert-manager                                                        |
 | [aws-external-dns](modules/aws-external-dns/) | -          | Terraform modules for managing IAM permissions on AWS for external-dns                                                        |
 

--- a/katalog/forecastle/README.md
+++ b/katalog/forecastle/README.md
@@ -11,7 +11,7 @@
 
 ## Image repository and tag
 
-- Forecastle image: `docker.io/stakater/forecastle:v1.0.125`
+- Forecastle image: `docker.io/stakater/forecastle:v1.0.136`
 - Forecastle repo: [https://github.com/stakater/Forecastle](https://github.com/stakater/Forecastle)
 
 ## Configuration

--- a/katalog/forecastle/deploy.yml
+++ b/katalog/forecastle/deploy.yml
@@ -27,7 +27,7 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: metadata.namespace
-          image: "stakater/forecastle:v1.0.131"
+          image: "stakater/forecastle:v1.0.136"
           name: forecastle
           livenessProbe:
             httpGet:


### PR DESCRIPTION
This PR update Forecastle to de version 1.0.136, was testing on a Kubernetes cluster  created using kind, the key points from the QA, and testing phase include:
## QA Highlights
- Deploy the workload in Kubernetes version 1.28.6 and 1.29.1
- validate forecastle's CRD functionally by successfully creating a CR and ings, which were both published in the services directory.