### PR TITLE
feat(external-dns): version bump v0.14.0 and formating

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ Kubernetes Fury Ingress provides the following packages:
 | [nginx](katalog/nginx)                        | `v1.9.4`   | The NGINX Ingress Controller for Kubernetes provides delivery services for Kubernetes applications.                           |
 | [dual-nginx](katalog/dual-nginx)              | `v1.9.4`   | It deploys two identical NGINX ingress controllers but with two different scopes: public/external and private/internal.       |
 | [cert-manager](katalog/cert-manager)          | `v1.13.1`  | cert-manager is a Kubernetes add-on to automate the management and issuance of TLS certificates from various issuing sources. |
-| [external-dns](katalog/external-dns)          | `v0.13.6`  | external-dns allows you to manage DNS records natively from Kubernetes.                                                       |
+| [external-dns](katalog/external-dns)          | `v0.14.0`  | external-dns allows you to manage DNS records natively from Kubernetes.                                                       |
 | [forecastle](katalog/forecastle)              | `v1.0.131` | Forecastle gives you access to a control panel where you can see your ingresses and access them on Kubernetes.                |
 | [aws-cert-manager](modules/aws-cert-manager/) | -          | Terraform modules for managing IAM permissions on AWS for cert-manager                                                        |
 | [aws-external-dns](modules/aws-external-dns/) | -          | Terraform modules for managing IAM permissions on AWS for external-dns                                                        |

--- a/katalog/external-dns/README.md
+++ b/katalog/external-dns/README.md
@@ -11,7 +11,7 @@ ExternalDNS synchronizes exposed Kubernetes Services and Ingresses with DNS prov
 
 ## Image repository and tag
 
-- ExternalDNS image: `k8s.gcr.io/external-dns/external-dns:v0.13.6`
+- ExternalDNS image: `k8s.gcr.io/external-dns/external-dns:v0.14.0`
 - ExternalDNS repo: [https://github.com/kubernetes-sigs/external-dns](https://github.com/kubernetes-sigs/external-dns)
 
 ## Deployment

--- a/katalog/external-dns/base/deploy.yml
+++ b/katalog/external-dns/base/deploy.yml
@@ -20,36 +20,36 @@ spec:
     spec:
       serviceAccountName: external-dns
       containers:
-      - name: external-dns
-        image: registry.k8s.io/external-dns/external-dns:v0.13.6
-        args:
-        - --source=service
-        - --source=ingress
-        - --provider=$(PROVIDER)
-        ports:
-        - name: metrics
-          containerPort: 7979
-        resources:
-          requests:
-            cpu: 50m
-            memory: 50Mi
-          limits:
-            cpu: 250m
-            memory: 250Mi
-        readinessProbe:
-          httpGet:
-            path: /healthz
-            port: metrics
-        livenessProbe:
-          failureThreshold: 2
-          httpGet:
-            path: /healthz
-            port: metrics
-        securityContext:
-          readOnlyRootFilesystem: true
-          capabilities:
-            drop:
-            - "ALL"
+        - name: external-dns
+          image: registry.k8s.io/external-dns/external-dns:v0.14.0
+          args:
+            - --source=service
+            - --source=ingress
+            - --provider=$(PROVIDER)
+          ports:
+            - name: metrics
+              containerPort: 7979
+          resources:
+            requests:
+              cpu: 50m
+              memory: 50Mi
+            limits:
+              cpu: 250m
+              memory: 250Mi
+          readinessProbe:
+            httpGet:
+              path: /healthz
+              port: metrics
+          livenessProbe:
+            failureThreshold: 2
+            httpGet:
+              path: /healthz
+              port: metrics
+          securityContext:
+            readOnlyRootFilesystem: true
+            capabilities:
+              drop:
+                - "ALL"
       securityContext:
         runAsNonRoot: true
         runAsUser: 65534
@@ -63,9 +63,9 @@ metadata:
     app: external-dns
 spec:
   ports:
-  - name: metrics
-    port: 7979
-    protocol: TCP
-    targetPort: metrics
+    - name: metrics
+      port: 7979
+      protocol: TCP
+      targetPort: metrics
   selector:
     app: external-dns

--- a/katalog/external-dns/base/rbac.yml
+++ b/katalog/external-dns/base/rbac.yml
@@ -12,47 +12,47 @@ kind: ClusterRole
 metadata:
   name: external-dns
 rules:
-- apiGroups:
-  - ""
-  resources:
-  - "services"
-  verbs:
-  - "get"
-  - "watch"
-  - "list"
-- apiGroups:
-  - ""
-  resources:
-  - "endpoints"
-  verbs:
-  - "get"
-  - "watch"
-  - "list"
-- apiGroups:
-  - ""
-  resources:
-  - "pods"
-  verbs:
-  - "get"
-  - "watch"
-  - "list"
-- apiGroups:
-  - "extensions"
-  - "networking.k8s.io"
-  resources:
-  - "ingresses"
-  verbs:
-  - "get"
-  - "watch"
-  - "list"
-- apiGroups:
-  - ""
-  resources:
-  - "nodes"
-  verbs:
-  - "get"
-  - "list"
-  - "watch"
+  - apiGroups:
+      - ""
+    resources:
+      - "services"
+    verbs:
+      - "get"
+      - "watch"
+      - "list"
+  - apiGroups:
+      - ""
+    resources:
+      - "endpoints"
+    verbs:
+      - "get"
+      - "watch"
+      - "list"
+  - apiGroups:
+      - ""
+    resources:
+      - "pods"
+    verbs:
+      - "get"
+      - "watch"
+      - "list"
+  - apiGroups:
+      - "extensions"
+      - "networking.k8s.io"
+    resources:
+      - "ingresses"
+    verbs:
+      - "get"
+      - "watch"
+      - "list"
+  - apiGroups:
+      - ""
+    resources:
+      - "nodes"
+    verbs:
+      - "get"
+      - "list"
+      - "watch"
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
@@ -63,6 +63,6 @@ roleRef:
   kind: ClusterRole
   name: external-dns
 subjects:
-- kind: ServiceAccount
-  name: external-dns
-  namespace: default
+  - kind: ServiceAccount
+    name: external-dns
+    namespace: default

--- a/katalog/external-dns/private/kustomization.yaml
+++ b/katalog/external-dns/private/kustomization.yaml
@@ -11,4 +11,3 @@ resources:
   - ../base
 
 nameSuffix: -private
-

--- a/katalog/external-dns/public/kustomization.yaml
+++ b/katalog/external-dns/public/kustomization.yaml
@@ -11,4 +11,3 @@ resources:
   - ../base
 
 nameSuffix: -public
-


### PR DESCRIPTION
This PR updates `external-dns` to the version `v0.14.0` and was  testing on Kubernetes clusters. The manifests format was update using the correct indentantion. 

Key points from the QA and testing phase include:

## QA Highlights:

- Tested on Kubernetes clusters using kind versions 1.29.1 and 1.28.6.
- Confirmed all workloads were operational across clusters.
- Validated the `external-dns` its capable to create, update and delete records using cloudflare provider. 