### PR TITLE
Nginx version bump v1.9.6

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,8 +38,8 @@ Kubernetes Fury Ingress provides the following packages:
 
 | Package                                       | Version    | Description                                                                                                                   |
 | --------------------------------------------- | ---------- | ----------------------------------------------------------------------------------------------------------------------------- |
-| [nginx](katalog/nginx)                        | `v1.9.4`   | The NGINX Ingress Controller for Kubernetes provides delivery services for Kubernetes applications.                           |
-| [dual-nginx](katalog/dual-nginx)              | `v1.9.4`   | It deploys two identical NGINX ingress controllers but with two different scopes: public/external and private/internal.       |
+| [nginx](katalog/nginx)                        | `v1.9.6`   | The NGINX Ingress Controller for Kubernetes provides delivery services for Kubernetes applications.                           |
+| [dual-nginx](katalog/dual-nginx)              | `v1.9.6`   | It deploys two identical NGINX ingress controllers but with two different scopes: public/external and private/internal.       |
 | [cert-manager](katalog/cert-manager)          | `v1.13.1`  | cert-manager is a Kubernetes add-on to automate the management and issuance of TLS certificates from various issuing sources. |
 | [external-dns](katalog/external-dns)          | `v0.13.6`  | external-dns allows you to manage DNS records natively from Kubernetes.                                                       |
 | [forecastle](katalog/forecastle)              | `v1.0.131` | Forecastle gives you access to a control panel where you can see your ingresses and access them on Kubernetes.                |

--- a/katalog/dual-nginx/README.md
+++ b/katalog/dual-nginx/README.md
@@ -12,7 +12,7 @@ Ingress NGINX is an Ingress Controller for [NGINX][nginx-page] webserver and rev
 
 ## Image repository and tag
 
-- Ingress NGINX image: `k8s.gcr.io/ingress-nginx/controller:v1.9.4`
+- Ingress NGINX image: `k8s.gcr.io/ingress-nginx/controller:v1.9.6`
 - Ingress NGINX repo: [https://github.com/kubernetes/ingress-nginx](https://github.com/kubernetes/ingress-nginx)
 
 ## Configuration

--- a/katalog/nginx/README.md
+++ b/katalog/nginx/README.md
@@ -12,7 +12,7 @@ Ingress NGINX is an Ingress Controller for [NGINX][nginx-page] web server and re
 
 ## Image repository and tag
 
-- Ingress NGINX image: `k8s.gcr.io/ingress-nginx/controller:v1.9.4`
+- Ingress NGINX image: `k8s.gcr.io/ingress-nginx/controller:v1.9.6`
 - Ingress NGINX repo: [https://github.com/kubernetes/ingress-nginx](https://github.com/kubernetes/ingress-nginx)
 
 ## Configuration

--- a/katalog/nginx/bases/controller/kustomization.yaml
+++ b/katalog/nginx/bases/controller/kustomization.yaml
@@ -11,7 +11,7 @@ namespace: ingress-nginx
 images:
   - name: k8s.gcr.io/ingress-nginx/controller
     newName: registry.sighup.io/fury/ingress-nginx/controller
-    newTag: v1.9.4
+    newTag: v1.9.6
 
 resources:
   - daemonset.yml


### PR DESCRIPTION
This PR updates nginx to version v1.9.6 and was tested on Kubernetes clusters. 

Key points from the QA and testing phase include:

### QA Highlights:

- Tested on Kubernetes clusters using kind versions 1.29.1 and 1.28.6.
- Confirmed all workloads were operational across clusters.
- Dual nginx implementation was tested with two ingress resources (internal and external) using a valid DNS record and NodePort services. 