### PR TITLE
Fix Nginx Prometheus Rules

### DIFF
--- a/katalog/nginx/bases/configs/rules.yml
+++ b/katalog/nginx/bases/configs/rules.yml
@@ -79,8 +79,7 @@ spec:
         doc: "This alert fires if the certificate for a given host is expiring
           in less than 7 days."
       expr: |
-        (avg by (host)
-          (nginx_ingress_controller_ssl_expire_time_seconds{job="ingress-nginx-metrics"})) < 604800
+        (avg(nginx_ingress_controller_ssl_expire_time_seconds{job="ingress-nginx-metrics"}) by (host) - time()) < 604800
       labels:
         severity: warning
     - alert: NginxIngressCertificateExpiration
@@ -90,7 +89,6 @@ spec:
         doc: "This alert fires if the certificate for a given host is expiring
           in less than 1 days."
       expr: |
-        (avg by (host)
-          (nginx_ingress_controller_ssl_expire_time_seconds{job="ingress-nginx-metrics"})) < 86400
+        (avg(nginx_ingress_controller_ssl_expire_time_seconds{job="ingress-nginx-metrics"}) by (host) - time()) < 86400
       labels:
         severity: critical


### PR DESCRIPTION
Hi 👋 

This PR is to fix the queries that generate certificate expiration alerts.

As of today, we just compute the value of nginx_ingress_controller_ssl_expire_time_seconds, but this is actually the epoch timestamp of the expiration date.

To measure how much time remains till the expiration, we need to subtract the current time, that is `time()`.