### PR TITLE
feat(ingress-nginx): bump to v1.12.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,9 +38,9 @@ The reference architecture used to deploy the Fury Kubernetes Ingress Module is 
 Kubernetes Fury Ingress provides the following packages:
 
 | Package                                       | Version    | Description                                                                                                                   |
-| --------------------------------------------- |------------| ----------------------------------------------------------------------------------------------------------------------------- |
-| [nginx](katalog/nginx)                        | `v1.11.3`  | The NGINX Ingress Controller for Kubernetes provides delivery services for Kubernetes applications.                           |
-| [dual-nginx](katalog/dual-nginx)              | `v1.11.3`  | It deploys two identical NGINX ingress controllers but with two different scopes: public/external and private/internal.       |
+| --------------------------------------------- | ---------- | ----------------------------------------------------------------------------------------------------------------------------- |
+| [nginx](katalog/nginx)                        | `v1.12.0`  | The NGINX Ingress Controller for Kubernetes provides delivery services for Kubernetes applications.                           |
+| [dual-nginx](katalog/dual-nginx)              | `v1.12.0`  | It deploys two identical NGINX ingress controllers but with two different scopes: public/external and private/internal.       |
 | [cert-manager](katalog/cert-manager)          | `v1.16.1`  | cert-manager is a Kubernetes add-on to automate the management and issuance of TLS certificates from various issuing sources. |
 | [external-dns](katalog/external-dns)          | `v0.15.0`  | external-dns allows you to manage DNS records natively from Kubernetes.                                                       |
 | [forecastle](katalog/forecastle)              | `v1.0.145` | Forecastle gives you access to a control panel where you can see your ingresses and access them on Kubernetes.                |
@@ -70,7 +70,7 @@ Check the [compatibility matrix][compatibility-matrix] for additional informatio
 | Tool                        | Version    | Description                                                                                                                                                    |
 | --------------------------- | ---------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | [furyctl][furyctl-repo]     | `>=0.25.0` | The recommended tool to download and manage KFD modules and their packages. To learn more about `furyctl` read the [official documentation][furyctl-repo].     |
-| [kustomize][kustomize-repo] | `>=3.10.0` | Packages are customized using `kustomize`. To learn how to create your customization layer with `kustomize`, please refer to the [repository][kustomize-repo]. |
+| [kustomize][kustomize-repo] | `>=5.6.0`  | Packages are customized using `kustomize`. To learn how to create your customization layer with `kustomize`, please refer to the [repository][kustomize-repo]. |
 
 ### Single vs Dual Controller
 
@@ -257,7 +257,7 @@ If you don't have infra nodes and you don't want to run ingress-controllers on a
 
 #### Applications directory with Forecastle
 
-Forecastle list all the annotated ingress (applications) that exists in your cluster with an icon grouped by namesapce, in a nice web UI. It lets you search, personalize the header for the landing page (title and colors), it lets you list custom ingress and add more details to each entry.
+Forecastle list all the annotated ingress (applications) that exists in your cluster with an icon grouped by namespace, in a nice web UI. It lets you search, personalize the header for the landing page (title and colors), it lets you list custom ingress and add more details to each entry.
 
 Use Forecastle as your cluster entry point to discover the running applications easily.
 
@@ -314,7 +314,6 @@ Add the following annotations to your ingresses to be discovered by Forecastle:
 <!-- Links -->
 
 [furyctl-repo]: https://github.com/sighupio/furyctl
-[sighup-page]: https://sighup.io
 [kfd-repo]: https://github.com/sighupio/fury-distribution
 [kustomize-repo]: https://github.com/kubernetes-sigs/kustomize
 [kfd-docs]: https://docs.kubernetesfury.com/docs/distribution/

--- a/docs/releases/unreleased.md
+++ b/docs/releases/unreleased.md
@@ -1,0 +1,68 @@
+# Kubernetes Fury Ingress Core Module Release TBD
+
+Welcome to the latest release of `Ingress` module of [`Kubernetes Fury Distribution`](https://github.com/sighupio/fury-distribution) maintained by team SIGHUP.
+
+This release updates several packages to the latest versions available for new features, bug fixes and improved security, it also introduces compatibility with Kubernetes 1.32.
+
+## Component versions 🚢
+
+| Component          | Supported Version                                                                        | Previous Version |
+| ------------------ | ---------------------------------------------------------------------------------------- | :--------------: |
+| `aws-cert-manager` | N.A.                                                                                     |   `No update`    |
+| `aws-external-dns` | N.A.                                                                                     |   `No update`    |
+| `cert-manager`     | [`v1.16.1`](https://github.com/jetstack/cert-manager/releases/tag/v1.16.1)               |     `1.16.1`     |
+| `external-dns`     | [`v0.15.0`](https://github.com/kubernetes-sigs/external-dns/releases/tag/v0.15.0)        |     `0.15.0`     |
+| `forecastle`       | [`v1.0.145`](https://github.com/stakater/Forecastle/releases/tag/v1.0.145)               |    `1.0.145`     |
+| `nginx`            | [`v1.12.0`](https://github.com/kubernetes/ingress-nginx/releases/tag/controller-v1.12.0) |     `1.11.3`     |
+
+> Please refer the individual release notes to get a more detailed information on each release.
+
+## Breaking changes 💔
+
+## Ingress NGINX Controller
+
+Upstream Ingress NGINX Controller has introduced some breaking changes in version 1.12.0 included in this version of the ingress module. We recommend reading [upstream's changelog](https://github.com/kubernetes/ingress-nginx/blob/main/changelog/controller-1.12.0.md). Here's a list of changes that could possibly impact you as a user of the module:
+
+- Remove `global-rate-limit` feature. This removes the following configuration options:
+
+  - `global-rate-limit-memcached-host`
+  - `global-rate-limit-memcached-port`
+  - `global-rate-limit-memcached-connect-timeout`
+  - `global-rate-limit-memcached-max-idle-timeout`
+  - `global-rate-limit-memcached-pool-size`
+  - `global-rate-limit-status-code`
+
+  It also removes the following annotations:
+
+  - `global-rate-limit`
+  - `global-rate-limit-window`
+  - `global-rate-limit-key`
+  - `global-rate-limit-ignored-cidrs`
+
+- Remove 3rd party lua plugin support. This removes the following configuration options:
+
+  - `plugins`
+
+  It also removes support for user provided Lua plugins in the `/etc/nginx/lua/plugins` directory.
+
+## Upgrade Guide 🦮
+
+> ⚠️ **WARNING**
+>
+> There are some (possibly) breaking changes, read the Breaking changes section above before continuing.
+<!-- spacer -->
+
+> ℹ️ **INFO**
+>
+> This update guide is for users of the module and not of the Distribution or users still on furyctl legacy.
+> If you are a KFD user, the update is performed automatically by furyctl.
+
+### Process
+
+To upgrade this core module from `v3.0.1` to `vTBD`, you need to download this new version and apply the instructions below.
+
+```bash
+kustomize build <your-project-path> | kubectl apply -f - --server-side
+```
+
+For the Terraform modules, run `terraform init -upgrade`, then apply the new version.

--- a/katalog/dual-nginx/README.md
+++ b/katalog/dual-nginx/README.md
@@ -6,13 +6,13 @@ Ingress NGINX is an Ingress Controller for [NGINX][nginx-page] webserver and rev
 
 ## Requirements
 
-- Kubernetes >= `1.25.0`
-- Kustomize >= `v3`
+- Kubernetes >= `1.28.0`
+- Kustomize >= `v5.6.0`
 - [`cert-manager`](../cert-manager)
 
 ## Image repository and tag
 
-- Ingress NGINX image: `k8s.gcr.io/ingress-nginx/controller:v1.11.3`
+- Ingress NGINX image: `k8s.gcr.io/ingress-nginx/controller:v1.12.0`
 - Ingress NGINX repo: [https://github.com/kubernetes/ingress-nginx](https://github.com/kubernetes/ingress-nginx)
 
 ## Configuration
@@ -67,7 +67,7 @@ Your are now ready to expose your applications using Kubernetes `Ingress` object
 
 This is probably NOT what you want, standard Fury clusters have at least 1 `infra` node (nodes that are dedicated to run Fury infrastructural components, like Prometheus, elasticsearch, and the ingress controllers).
 
-If your cluster has `infra` nodes you should patch the daemonset adding the `NodeSelector` for the `infra` nodes to the Ingress `DaemonSet`. You can do this usiing the following kustomize patch:
+If your cluster has `infra` nodes you should patch the daemonset adding the `NodeSelector` for the `infra` nodes to the Ingress `DaemonSet`. You can do this using the following kustomize patch:
 
 ```yaml
 ---

--- a/katalog/dual-nginx/external/kustomization.yaml
+++ b/katalog/dual-nginx/external/kustomization.yaml
@@ -11,11 +11,13 @@ transformers:
 resources:
   - ../../nginx/bases/controller
 
-commonLabels:
-  app: ingress
-  type: external
+labels:
+  - includeSelectors: true
+    pairs:
+      app: ingress
+      type: external
 
-patchesJson6902:
+patches:
   - target:
       group: apps
       version: v1
@@ -23,13 +25,11 @@ patchesJson6902:
       name: ingress-nginx-controller
     path: patch/daemonset.yml
   - target:
-      group: ""
       version: v1
       kind: Service
       name: ingress-nginx
     path: patch/service.yml
   - target:
-      group: ""
       version: v1
       kind: ConfigMap
       name: ingress-nginx-controller
@@ -46,21 +46,18 @@ patchesJson6902:
       kind: ValidatingWebhookConfiguration
       name: ingress-nginx-admission
     path: patch/validating-webhook.yml
-
-patches:
-- target:
-    kind: IngressClass
-    name: nginx
-  patch: |-
-    - op: replace
-      path: /metadata/name
-      value: external
-    - op: remove
-      path: /metadata/annotations
-    - op: replace
-      path: "/apiVersion"
-      value: networking.k8s.io/v1
-    - op: replace
-      path: /spec/controller
-      value: k8s.io/external
-
+  - target:
+      kind: IngressClass
+      name: nginx
+    patch: |-
+      - op: replace
+        path: /metadata/name
+        value: external
+      - op: remove
+        path: /metadata/annotations
+      - op: replace
+        path: "/apiVersion"
+        value: networking.k8s.io/v1
+      - op: replace
+        path: /spec/controller
+        value: k8s.io/external

--- a/katalog/dual-nginx/external/patch/cm.yml
+++ b/katalog/dual-nginx/external/patch/cm.yml
@@ -2,7 +2,6 @@
 # Use of this source code is governed by a BSD-style
 # license that can be found in the LICENSE file.
 
-- op: "replace"
+# Remove Helm labels
+- op: "remove"
   path: "/metadata/labels"
-  value:
-    app: ingress-external

--- a/katalog/dual-nginx/external/patch/suffix.yml
+++ b/katalog/dual-nginx/external/patch/suffix.yml
@@ -9,13 +9,17 @@ metadata:
   name: externalSuffix
 suffix: "-external"
 fieldSpecs:
-- kind: ConfigMap
-  path: metadata/name
-- kind: Service
-  path: metadata/name
-- kind: DaemonSet
-  path: metadata/name
-- kind: Certificate
-  path: metadata/name
-- kind: ValidatingWebhookConfiguration
-  path: metadata/name
+  - kind: ConfigMap
+    path: metadata/name
+  - kind: ConfigMap
+    path: metadata/labels/app
+  - kind: Service
+    path: metadata/name
+  - kind: DaemonSet
+    path: metadata/name
+  - kind: Certificate
+    path: metadata/name
+  - kind: Certificate
+    path: metadata/labels/app
+  - kind: ValidatingWebhookConfiguration
+    path: metadata/name

--- a/katalog/dual-nginx/external/patch/tls-cert.yml
+++ b/katalog/dual-nginx/external/patch/tls-cert.yml
@@ -2,10 +2,8 @@
 # Use of this source code is governed by a BSD-style
 # license that can be found in the LICENSE file.
 
-- op: "replace"
+- op: "remove"
   path: "/metadata/labels"
-  value:
-    app: ingress-external
 
 - op: "replace"
   path: "/spec/secretName"

--- a/katalog/dual-nginx/internal/kustomization.yaml
+++ b/katalog/dual-nginx/internal/kustomization.yaml
@@ -11,11 +11,13 @@ transformers:
 resources:
   - ../../nginx/bases/controller
 
-commonLabels:
-  app: ingress
-  type: internal
+labels:
+  - includeSelectors: true
+    pairs:
+      app: ingress
+      type: internal
 
-patchesJson6902:
+patches:
   - target:
       group: apps
       version: v1
@@ -23,13 +25,11 @@ patchesJson6902:
       name: ingress-nginx-controller
     path: patch/daemonset.yml
   - target:
-      group: ""
       version: v1
       kind: Service
       name: ingress-nginx
     path: patch/service.yml
   - target:
-      group: ""
       version: v1
       kind: ConfigMap
       name: ingress-nginx-controller
@@ -46,21 +46,19 @@ patchesJson6902:
       kind: ValidatingWebhookConfiguration
       name: ingress-nginx-admission
     path: patch/validating-webhook.yml
-
-patches:
-- target:
-    kind: IngressClass
-    name: nginx
-    version: v1
-  patch: |-
-    - op: replace
-      path: /metadata/name
-      value: internal
-    - op: remove
-      path: /metadata/annotations
-    - op: replace
-      path: "/apiVersion"
-      value: networking.k8s.io/v1
-    - op: replace
-      path: /spec/controller
-      value: k8s.io/internal
+  - target:
+      kind: IngressClass
+      name: nginx
+      version: v1
+    patch: |-
+      - op: replace
+        path: /metadata/name
+        value: internal
+      - op: remove
+        path: /metadata/annotations
+      - op: replace
+        path: "/apiVersion"
+        value: networking.k8s.io/v1
+      - op: replace
+        path: /spec/controller
+        value: k8s.io/internal

--- a/katalog/dual-nginx/internal/patch/cm.yml
+++ b/katalog/dual-nginx/internal/patch/cm.yml
@@ -2,7 +2,6 @@
 # Use of this source code is governed by a BSD-style
 # license that can be found in the LICENSE file.
 
-- op: "replace"
+# Remove Helm labels
+- op: "remove"
   path: "/metadata/labels"
-  value:
-    app: ingress-internal

--- a/katalog/dual-nginx/internal/patch/suffix.yml
+++ b/katalog/dual-nginx/internal/patch/suffix.yml
@@ -9,13 +9,17 @@ metadata:
   name: internalSuffix
 suffix: "-internal"
 fieldSpecs:
-- kind: ConfigMap
-  path: metadata/name
-- kind: Service
-  path: metadata/name
-- kind: DaemonSet
-  path: metadata/name
-- kind: Certificate
-  path: metadata/name
-- kind: ValidatingWebhookConfiguration
-  path: metadata/name
+  - kind: ConfigMap
+    path: metadata/name
+  - kind: ConfigMap
+    path: metadata/labels/app
+  - kind: Service
+    path: metadata/name
+  - kind: DaemonSet
+    path: metadata/name
+  - kind: Certificate
+    path: metadata/name
+  - kind: Certificate
+    path: metadata/labels/app
+  - kind: ValidatingWebhookConfiguration
+    path: metadata/name

--- a/katalog/dual-nginx/internal/patch/tls-cert.yml
+++ b/katalog/dual-nginx/internal/patch/tls-cert.yml
@@ -2,10 +2,8 @@
 # Use of this source code is governed by a BSD-style
 # license that can be found in the LICENSE file.
 
-- op: "replace"
+- op: "remove"
   path: "/metadata/labels"
-  value:
-    app: ingress-internal
 
 - op: "replace"
   path: "/spec/secretName"

--- a/katalog/nginx/MAINTENANCE.md
+++ b/katalog/nginx/MAINTENANCE.md
@@ -1,6 +1,6 @@
-# NGINX ingress controller package maintenance guide
+# Ingress NGINX controller package maintenance guide
 
-To update NGINX ingress controller, follow the next steps (or use the [upgrade.sh](./upgrade.sh) script to automate it):
+To update Ingress NGINX controller, follow the next steps (or update and use the [upgrade.sh](./upgrade.sh) script to automate it):
 
 ## Local build
 
@@ -11,17 +11,19 @@ kustomize build . > current-release.yaml
 ```
 
 > 💡 TIP
-> Comment out the grafana dashboard resource from the katalog/nginx/kustomization.yaml file.
+> Comment out the Grafana dashboard resource from the `katalog/nginx/kustomization.yaml` file.
 > It adds 5000 lines from the JSON that are not needed in the diff and may break your editor.
-
 
 ## Upgrade files
 
-1. Go to the [NGINX ingress controller repository](https://github.com/kubernetes/ingress-nginx/) and check the latest release.
+1. Go to the [ingress NGINX controller repository](https://github.com/kubernetes/ingress-nginx/) and check the latest release.
 
-> Controller releases are published as `controller-vX.Y.Z` tags.
+> 💡 TIP
+> Controller releases are published as `controller-vX.Y.Z` tags and chart releases with `helm-chart-X.Y.Z`.
+>
+> You can also find a compatibility table in the project's [main README file](https://github.com/kubernetes/ingress-nginx?tab=readme-ov-file#supported-versions-table).
 
-2. Helm template the content using the following command:
+1. Helm template the content using the following command:
 
 ```bash
 helm template ingress-nginx ingress-nginx \
@@ -66,13 +68,15 @@ kustomize build . > new-release.yaml
 ```
 
 > 💡 TIP
-> Comment out the grafana dashboard resource from the katalog/nginx/kustomization.yaml file.
+> Comment out the Grafana dashboard resource from the katalog/nginx/kustomization.yaml file.
 > It adds 5000 lines from the JSON that are not needed in the diff and may break your editor.
 
 2. Compare the two releases
 
 ```bash
 bcompare current-release.yaml new-release.yaml
+# OR
+dyff between current-release.yaml new-release.yaml
 # OR
 diff current-release.yaml new-release.yaml
 ```
@@ -92,7 +96,6 @@ go install github.com/google/addlicense@v1.1.1
 addlicense -c "SIGHUP s.r.l" -y "2017-present" -v -l bsd .
 ```
 
-## Updata Grafana Dashboards
+## Update Grafana Dashboards
 
-check the grafana dashboard in this path: `deploy/grafana/dashboards/nginx.json` of the upstream repository
-compare the upstream with the current one, and update it if is needed.
+Check the Grafana dashboard in the [`deploy/Grafana/dashboards/`](https://github.com/kubernetes/ingress-nginx/tree/main/deploy/grafana/dashboards) path of the upstream repository, compare the upstream with the current one and update it if is needed.

--- a/katalog/nginx/README.md
+++ b/katalog/nginx/README.md
@@ -6,13 +6,13 @@ Ingress NGINX is an Ingress Controller for [NGINX][nginx-page] web server and re
 
 ## Requirements
 
-- Kubernetes >= `1.25.0`
-- Kustomize >= `v3`
+- Kubernetes >= `1.28.0`
+- Kustomize >= `v5.6.0`
 - `cert-manager`
 
 ## Image repository and tag
 
-- Ingress NGINX image: `k8s.gcr.io/ingress-nginx/controller:v1.11.3`
+- Ingress NGINX image: `k8s.gcr.io/ingress-nginx/controller:v1.12.0`
 - Ingress NGINX repo: [https://github.com/kubernetes/ingress-nginx](https://github.com/kubernetes/ingress-nginx)
 
 ## Configuration

--- a/katalog/nginx/bases/configs/ClusterRole-ingress-nginx.yml
+++ b/katalog/nginx/bases/configs/ClusterRole-ingress-nginx.yml
@@ -8,10 +8,10 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   labels:
-    helm.sh/chart: ingress-nginx-4.11.3
+    helm.sh/chart: ingress-nginx-4.12.0
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/version: "1.11.3"
+    app.kubernetes.io/version: "1.12.0"
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/managed-by: Helm
   name: ingress-nginx

--- a/katalog/nginx/bases/configs/ClusterRoleBinding-ingress-nginx.yml
+++ b/katalog/nginx/bases/configs/ClusterRoleBinding-ingress-nginx.yml
@@ -8,10 +8,10 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   labels:
-    helm.sh/chart: ingress-nginx-4.11.3
+    helm.sh/chart: ingress-nginx-4.12.0
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/version: "1.11.3"
+    app.kubernetes.io/version: "1.12.0"
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/managed-by: Helm
   name: ingress-nginx

--- a/katalog/nginx/bases/configs/PrometheusRule-ingress-nginx-controller.yml
+++ b/katalog/nginx/bases/configs/PrometheusRule-ingress-nginx-controller.yml
@@ -10,10 +10,10 @@ metadata:
   name: ingress-nginx-controller
   namespace: ingress-nginx
   labels:
-    helm.sh/chart: ingress-nginx-4.11.3
+    helm.sh/chart: ingress-nginx-4.12.0
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/version: "1.11.3"
+    app.kubernetes.io/version: "1.12.0"
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: controller

--- a/katalog/nginx/bases/configs/Role-ingress-nginx.yml
+++ b/katalog/nginx/bases/configs/Role-ingress-nginx.yml
@@ -8,10 +8,10 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   labels:
-    helm.sh/chart: ingress-nginx-4.11.3
+    helm.sh/chart: ingress-nginx-4.12.0
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/version: "1.11.3"
+    app.kubernetes.io/version: "1.12.0"
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: controller

--- a/katalog/nginx/bases/configs/RoleBinding-ingress-nginx.yml
+++ b/katalog/nginx/bases/configs/RoleBinding-ingress-nginx.yml
@@ -8,10 +8,10 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   labels:
-    helm.sh/chart: ingress-nginx-4.11.3
+    helm.sh/chart: ingress-nginx-4.12.0
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/version: "1.11.3"
+    app.kubernetes.io/version: "1.12.0"
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: controller

--- a/katalog/nginx/bases/configs/Service-ingress-nginx-controller-metrics.yml
+++ b/katalog/nginx/bases/configs/Service-ingress-nginx-controller-metrics.yml
@@ -8,10 +8,10 @@ apiVersion: v1
 kind: Service
 metadata:
   labels:
-    helm.sh/chart: ingress-nginx-4.11.3
+    helm.sh/chart: ingress-nginx-4.12.0
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/version: "1.11.3"
+    app.kubernetes.io/version: "1.12.0"
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: controller

--- a/katalog/nginx/bases/configs/ServiceAccount-ingress-nginx.yml
+++ b/katalog/nginx/bases/configs/ServiceAccount-ingress-nginx.yml
@@ -8,10 +8,10 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   labels:
-    helm.sh/chart: ingress-nginx-4.11.3
+    helm.sh/chart: ingress-nginx-4.12.0
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/version: "1.11.3"
+    app.kubernetes.io/version: "1.12.0"
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: controller

--- a/katalog/nginx/bases/configs/ServiceMonitor-ingress-nginx-controller.yml
+++ b/katalog/nginx/bases/configs/ServiceMonitor-ingress-nginx-controller.yml
@@ -10,19 +10,15 @@ metadata:
   name: ingress-nginx-controller
   namespace: ingress-nginx
   labels:
-    helm.sh/chart: ingress-nginx-4.11.3
+    helm.sh/chart: ingress-nginx-4.12.0
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/version: "1.11.3"
+    app.kubernetes.io/version: "1.12.0"
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: controller
     k8s-app: ingress-nginx
 spec:
-  endpoints:
-    - port: metrics
-      interval: 10s
-  jobLabel: "k8s-app"
   namespaceSelector:
     matchNames:
       - ingress-nginx
@@ -31,3 +27,7 @@ spec:
       app.kubernetes.io/name: ingress-nginx
       app.kubernetes.io/instance: ingress-nginx
       app.kubernetes.io/component: controller
+  endpoints:
+    - port: metrics
+      interval: 10s
+  jobLabel: "k8s-app"

--- a/katalog/nginx/bases/configs/dashboards/kustomization.yaml
+++ b/katalog/nginx/bases/configs/dashboards/kustomization.yaml
@@ -19,3 +19,4 @@ configMapGenerator:
   - name: ingress-grafana-dashboard
     files:
       - nginx-ingress.json
+      - request-handling-performance.json

--- a/katalog/nginx/bases/configs/dashboards/request-handling-performance.json
+++ b/katalog/nginx/bases/configs/dashboards/request-handling-performance.json
@@ -1,0 +1,986 @@
+{
+  "__inputs": [
+    {
+      "name": "DS_PROMETHEUS",
+      "label": "Prometheus",
+      "description": "",
+      "type": "datasource",
+      "pluginId": "prometheus",
+      "pluginName": "Prometheus"
+    }
+  ],
+  "__elements": {},
+  "__requires": [
+    {
+      "type": "grafana",
+      "id": "grafana",
+      "name": "Grafana",
+      "version": "10.4.3"
+    },
+    {
+      "type": "datasource",
+      "id": "prometheus",
+      "name": "Prometheus",
+      "version": "1.0.0"
+    },
+    {
+      "type": "panel",
+      "id": "timeseries",
+      "name": "Time series",
+      "version": ""
+    }
+  ],
+  "annotations": {
+    "list": [
+      {
+        "builtIn": 1,
+        "datasource": {
+          "type": "datasource",
+          "uid": "grafana"
+        },
+        "enable": true,
+        "hide": true,
+        "iconColor": "rgba(0, 211, 255, 1)",
+        "name": "Annotations & Alerts",
+        "target": {
+          "limit": 100,
+          "matchAny": false,
+          "tags": [],
+          "type": "dashboard"
+        },
+        "type": "dashboard"
+      }
+    ]
+  },
+  "description": "",
+  "editable": true,
+  "fiscalYearStartMonth": 0,
+  "gnetId": 9614,
+  "graphTooltip": 1,
+  "id": null,
+  "links": [],
+  "liveNow": false,
+  "panels": [
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "description": "Total time for NGINX and upstream servers to process a request and send a response",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "links": [],
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "s"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 0
+      },
+      "id": 91,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "pluginVersion": "10.4.3",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "expr": "histogram_quantile(\n  0.5,\n  sum by (le)(\n    rate(\n      nginx_ingress_controller_request_duration_seconds_bucket{\n        ingress =~ \"$ingress\"\n      }[5m]\n    )\n  )\n)",
+          "interval": "",
+          "legendFormat": ".5",
+          "refId": "D"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "expr": "histogram_quantile(\n  0.95,\n  sum by (le)(\n    rate(\n    nginx_ingress_controller_request_duration_seconds_bucket{\n        ingress =~ \"$ingress\"\n      }[5m]\n    )\n  )\n)",
+          "interval": "",
+          "legendFormat": ".95",
+          "refId": "B"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "expr": "histogram_quantile(\n  0.99,\n  sum by (le)(\n    rate(\n      nginx_ingress_controller_request_duration_seconds_bucket{\n        ingress =~ \"$ingress\"\n      }[5m]\n    )\n  )\n)",
+          "interval": "",
+          "legendFormat": ".99",
+          "refId": "A"
+        }
+      ],
+      "title": "Request Latency Percentiles",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "description": "The time spent on receiving the response from the upstream server",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "links": [],
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "s"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 0
+      },
+      "id": 94,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "pluginVersion": "10.4.3",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "expr": "histogram_quantile(\n  0.5,\n  sum by (le)(\n    rate(\n      nginx_ingress_controller_response_duration_seconds_bucket{\n        ingress =~ \"$ingress\"\n      }[5m]\n    )\n  )\n)",
+          "instant": false,
+          "interval": "",
+          "intervalFactor": 1,
+          "legendFormat": ".5",
+          "refId": "D"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "expr": "histogram_quantile(\n  0.95,\n  sum by (le)(\n    rate(\n    nginx_ingress_controller_response_duration_seconds_bucket{\n        ingress =~ \"$ingress\"\n      }[5m]\n    )\n  )\n)",
+          "interval": "",
+          "legendFormat": ".95",
+          "refId": "B"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "expr": "histogram_quantile(\n  0.99,\n  sum by (le)(\n    rate(\n      nginx_ingress_controller_response_duration_seconds_bucket{\n        ingress =~ \"$ingress\"\n      }[5m]\n    )\n  )\n)",
+          "interval": "",
+          "legendFormat": ".99",
+          "refId": "A"
+        }
+      ],
+      "title": "Upstream Response Latency Percentiles",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "links": [],
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "reqps"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 8
+      },
+      "id": 93,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "table",
+          "placement": "right",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "pluginVersion": "10.4.3",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "expr": "  sum by (method, host, path)(\n    rate(\n      nginx_ingress_controller_request_duration_seconds_count{\n        ingress =~ \"$ingress\"\n      }[5m]\n    )\n  )\n",
+          "interval": "",
+          "intervalFactor": 1,
+          "legendFormat": "{{ method }} {{ host }}{{path }}",
+          "refId": "A"
+        }
+      ],
+      "title": "Request Rate by Method and Path",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "description": "For each path observed, its median upstream response time",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "links": [],
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "s"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 8
+      },
+      "id": 98,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "table",
+          "placement": "right",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "pluginVersion": "10.4.3",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "expr": "histogram_quantile(\n  .5,\n  sum by (le, method, host, path)(\n    rate(\n      nginx_ingress_controller_response_duration_seconds_bucket{\n        ingress =~ \"$ingress\"\n      }[5m]\n    )\n  )\n)",
+          "interval": "",
+          "intervalFactor": 1,
+          "legendFormat": "{{ method }} {{ host }}{{path }}",
+          "refId": "A"
+        }
+      ],
+      "title": "Median Upstream Response Time by Method and Path",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "description": "Percentage of 4xx and 5xx responses among all responses.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "links": [],
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "percentunit"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 16
+      },
+      "id": 100,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "table",
+          "placement": "right",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "pluginVersion": "10.4.3",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "expr": "sum by (method, host, path) (rate(nginx_ingress_controller_request_duration_seconds_count{\n  ingress =~ \"$ingress\",\n  status =~ \"[4-5].*\"\n}[5m])) / sum by (method, host, path) (rate(nginx_ingress_controller_request_duration_seconds_count{\n  ingress =~ \"$ingress\",\n}[5m]))",
+          "interval": "",
+          "intervalFactor": 1,
+          "legendFormat": "{{ method }} {{ host }}{{path }}",
+          "refId": "A"
+        }
+      ],
+      "title": "Response Error Rate by Method and Path",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "description": "For each path observed, the sum of upstream request time",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "links": [],
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "s"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 16
+      },
+      "id": 102,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "table",
+          "placement": "right",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "pluginVersion": "10.4.3",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "expr": "sum by (method, host, path) (rate(nginx_ingress_controller_response_duration_seconds_sum{ingress =~ \"$ingress\"}[5m]))",
+          "interval": "",
+          "intervalFactor": 1,
+          "legendFormat": "{{ method }} {{ host }}{{path }}",
+          "refId": "A"
+        }
+      ],
+      "title": "Upstream Response Time by Method and Path",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "links": [],
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "reqps"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 24
+      },
+      "id": 101,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "table",
+          "placement": "right",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "pluginVersion": "10.4.3",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "expr": "  sum (\n    rate(\n      nginx_ingress_controller_request_duration_seconds_count{\n        ingress =~ \"$ingress\",\n        status =~\"[4-5].*\",\n      }[5m]\n    )\n  ) by(method, host, path, status)\n",
+          "interval": "",
+          "intervalFactor": 1,
+          "legendFormat": "{{ method }} {{ host }}{{path }} {{ status }}",
+          "refId": "A"
+        }
+      ],
+      "title": "Response Error Rate by Method and Path",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "links": [],
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "decbytes"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 24
+      },
+      "id": 99,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "table",
+          "placement": "right",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "pluginVersion": "10.4.3",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "expr": "sum (\n  rate (\n      nginx_ingress_controller_response_size_sum {\n        ingress =~ \"$ingress\",\n      }[5m]\n  )\n)  by (method, host, path) / sum (\n  rate(\n      nginx_ingress_controller_response_size_count {\n        ingress =~ \"$ingress\",\n      }[5m]\n  )\n) by (method, host, path)\n",
+          "hide": false,
+          "instant": false,
+          "interval": "",
+          "intervalFactor": 1,
+          "legendFormat": "{{ method }} {{ host }}{{path }}",
+          "refId": "D"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "expr": "    sum (rate(nginx_ingress_controller_response_size_bucket{\n        ingress =~ \"$ingress\",\n    }[5m])) by (le)\n",
+          "hide": true,
+          "legendFormat": "{{le}}",
+          "refId": "A"
+        }
+      ],
+      "title": "Average Response Size by Method and Path",
+      "type": "timeseries"
+    }
+  ],
+  "refresh": "30s",
+  "schemaVersion": 39,
+  "tags": [
+    "nginx"
+  ],
+  "templating": {
+    "list": [
+      {
+        "current": {
+          "selected": false,
+          "text": "Prometheus",
+          "value": "${DS_PROMETHEUS}"
+        },
+        "hide": 0,
+        "includeAll": false,
+        "label": "datasource",
+        "multi": false,
+        "name": "DS_PROMETHEUS",
+        "options": [],
+        "query": "prometheus",
+        "refresh": 1,
+        "regex": "",
+        "skipUrlSync": false,
+        "type": "datasource"
+      },
+      {
+        "allValue": ".*",
+        "current": {},
+        "datasource": {
+          "type": "prometheus",
+          "uid": "${DS_PROMETHEUS}"
+        },
+        "definition": "label_values(nginx_ingress_controller_requests, ingress) ",
+        "hide": 0,
+        "includeAll": true,
+        "label": "Service Ingress",
+        "multi": false,
+        "name": "ingress",
+        "options": [],
+        "query": {
+          "query": "label_values(nginx_ingress_controller_requests, ingress) ",
+          "refId": "Prometheus-ingress-Variable-Query"
+        },
+        "refresh": 1,
+        "regex": "",
+        "skipUrlSync": false,
+        "sort": 2,
+        "tagValuesQuery": "",
+        "tagsQuery": "",
+        "type": "query",
+        "useTags": false
+      }
+    ]
+  },
+  "time": {
+    "from": "now-15m",
+    "to": "now"
+  },
+  "timepicker": {
+    "refresh_intervals": [
+      "5s",
+      "10s",
+      "30s",
+      "2m",
+      "5m",
+      "15m",
+      "30m",
+      "1h",
+      "2h",
+      "1d"
+    ],
+    "time_options": [
+      "5m",
+      "15m",
+      "1h",
+      "6h",
+      "12h",
+      "24h",
+      "2d",
+      "7d",
+      "30d"
+    ]
+  },
+  "timezone": "browser",
+  "title": "Request Handling Performance",
+  "uid": "4GFbkOsZk",
+  "version": 1,
+  "weekStart": ""
+}

--- a/katalog/nginx/bases/controller/ConfigMap-ingress-nginx-controller.yml
+++ b/katalog/nginx/bases/controller/ConfigMap-ingress-nginx-controller.yml
@@ -8,10 +8,10 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   labels:
-    helm.sh/chart: ingress-nginx-4.11.3
+    helm.sh/chart: ingress-nginx-4.12.0
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/version: "1.11.3"
+    app.kubernetes.io/version: "1.12.0"
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: controller

--- a/katalog/nginx/bases/controller/DaemonSet-ingress-nginx-controller.yml
+++ b/katalog/nginx/bases/controller/DaemonSet-ingress-nginx-controller.yml
@@ -8,10 +8,10 @@ apiVersion: apps/v1
 kind: DaemonSet
 metadata:
   labels:
-    helm.sh/chart: ingress-nginx-4.11.3
+    helm.sh/chart: ingress-nginx-4.12.0
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/version: "1.11.3"
+    app.kubernetes.io/version: "1.12.0"
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: controller
@@ -33,10 +33,10 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: ingress-nginx-4.11.3
+        helm.sh/chart: ingress-nginx-4.12.0
         app.kubernetes.io/name: ingress-nginx
         app.kubernetes.io/instance: ingress-nginx
-        app.kubernetes.io/version: "1.11.3"
+        app.kubernetes.io/version: "1.12.0"
         app.kubernetes.io/part-of: ingress-nginx
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/component: controller
@@ -46,7 +46,7 @@ spec:
         fsGroup: 101
       containers:
         - name: controller
-          image: registry.sighup.io/fury/ingress-nginx/controller:v1.11.3
+          image: registry.sighup.io/fury/ingress-nginx/controller:v1.12.0
           imagePullPolicy: Always
           lifecycle:
             preStop:
@@ -63,11 +63,13 @@ spec:
             - --validating-webhook=:9443
             - --validating-webhook-certificate=/usr/local/certificates/cert
             - --validating-webhook-key=/usr/local/certificates/key
+            - --enable-metrics=true
             - --http-port=8080
             - --https-port=8443
           securityContext:
             runAsNonRoot: true
             runAsUser: 101
+            runAsGroup: 82
             allowPrivilegeEscalation: false
             seccompProfile:
               type: RuntimeDefault

--- a/katalog/nginx/bases/controller/IngressClass-nginx.yml
+++ b/katalog/nginx/bases/controller/IngressClass-nginx.yml
@@ -8,10 +8,10 @@ apiVersion: networking.k8s.io/v1
 kind: IngressClass
 metadata:
   labels:
-    helm.sh/chart: ingress-nginx-4.11.3
+    helm.sh/chart: ingress-nginx-4.12.0
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/version: "1.11.3"
+    app.kubernetes.io/version: "1.12.0"
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: controller

--- a/katalog/nginx/bases/controller/Service-ingress-nginx-controller-admission.yml
+++ b/katalog/nginx/bases/controller/Service-ingress-nginx-controller-admission.yml
@@ -8,10 +8,10 @@ apiVersion: v1
 kind: Service
 metadata:
   labels:
-    helm.sh/chart: ingress-nginx-4.11.3
+    helm.sh/chart: ingress-nginx-4.12.0
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/version: "1.11.3"
+    app.kubernetes.io/version: "1.12.0"
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: controller

--- a/katalog/nginx/bases/controller/Service-ingress-nginx-controller.yml
+++ b/katalog/nginx/bases/controller/Service-ingress-nginx-controller.yml
@@ -9,10 +9,10 @@ kind: Service
 metadata:
   annotations:
   labels:
-    helm.sh/chart: ingress-nginx-4.11.3
+    helm.sh/chart: ingress-nginx-4.12.0
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/version: "1.11.3"
+    app.kubernetes.io/version: "1.12.0"
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: controller

--- a/katalog/nginx/bases/controller/ValidatingWebhookConfiguration-ingress-nginx-admission.yml
+++ b/katalog/nginx/bases/controller/ValidatingWebhookConfiguration-ingress-nginx-admission.yml
@@ -13,10 +13,10 @@ metadata:
     certmanager.k8s.io/inject-ca-from: "ingress-nginx/ingress-nginx-admission"
     cert-manager.io/inject-ca-from: "ingress-nginx/ingress-nginx-admission"
   labels:
-    helm.sh/chart: ingress-nginx-4.11.3
+    helm.sh/chart: ingress-nginx-4.12.0
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/version: "1.11.3"
+    app.kubernetes.io/version: "1.12.0"
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: admission-webhook

--- a/katalog/nginx/bases/controller/kustomization.yaml
+++ b/katalog/nginx/bases/controller/kustomization.yaml
@@ -8,9 +8,11 @@ kind: Kustomization
 
 namespace: ingress-nginx
 
-commonLabels:
-  app: ingress-nginx
-  
+labels:
+  - includeSelectors: true
+    pairs:
+      app: ingress-nginx
+
 images:
   - name: k8s.gcr.io/ingress-nginx/controller
     newName: registry.sighup.io/fury/ingress-nginx/controller
@@ -27,11 +29,11 @@ resources:
 
 # We patch the service name for backwards compatibility with previous releases and to be able to upgrade without downtime.
 patches:
-- target:
-    kind: Service
-    name: ingress-nginx-controller
-    version: v1
-  patch: |-
-    - op: replace
-      path: /metadata/name
-      value: ingress-nginx
+  - target:
+      kind: Service
+      name: ingress-nginx-controller
+      version: v1
+    patch: |-
+      - op: replace
+        path: /metadata/name
+        value: ingress-nginx

--- a/katalog/nginx/kustomization.yaml
+++ b/katalog/nginx/kustomization.yaml
@@ -2,7 +2,6 @@
 # Use of this source code is governed by a BSD-style
 # license that can be found in the LICENSE file.
 
----
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 

--- a/katalog/nginx/upgrade.sh
+++ b/katalog/nginx/upgrade.sh
@@ -7,13 +7,13 @@
 kustomize build . > current-release.yaml
 
 # Remember to change this version accordingly
-VERSION=4.11.3
+VERSION=4.12.0
 
 helm template ingress-nginx ingress-nginx \
   --repo https://kubernetes.github.io/ingress-nginx \
   --namespace ingress-nginx --create-namespace --version $VERSION --values MAINTENANCE.values.yml | yq -s '.kind + "-" + .metadata.name'
 
-rm .yml
+rm .yml # sometimes we get an empty file called like this
 mv Certificate-ingress-nginx-root-cert.yml bases/configs
 mv ClusterRole-ingress-nginx.yml bases/configs
 mv ClusterRoleBinding-ingress-nginx.yml bases/configs


### PR DESCRIPTION
### Summary 💡

- Bumped Ingress Nginx to v1.12.0, adding support for Kubernetes 1.32.
- Added new "performance" dashboard
- Updated docs
- Updated kustomize projects for v5.6.0 compatibility

Closes https://github.com/sighupio/product-management/issues/573

### Description 📝

Bumped NGINX Controller to v1.12.0, that is the latest version available at the time of this writing and is compatible with Kubernetes 1.32 as per their support matrix.

Added a new dashboard taken from upstream nginx repository. There were no updates for the already included dashboard.

Updated all relevant documents.

Updated all the `nginx`, `dual-nginx` packages to support Kustomize v5.6.0, dropping `commonLabels` and `patchesJson6902` that have been marked as deprecated and using `labels` and `patches` instead. Notice that updating the kustomize projects to drop deprecated fields (like `commonLabels` and `patchesJson6902`) had a side-effects that I could not solve.

The side-effects are the following changes:

```diff

@@ metadata.labels @@
# v1/ConfigMap/ingress-nginx/ingress-nginx-controller-external
! + one map entry added:
+   type: external

@@ metadata.labels @@
# cert-manager.io/v1/Certificate/ingress-nginx/ingress-nginx-admission-external
! + one map entry added:
+   type: external
```

and the same for the internal ingress controller:

```diff
@@ metadata.labels @@
# v1/ConfigMap/ingress-nginx/ingress-nginx-controller-internal
! + one map entry added:
+   type: internal

@@ metadata.labels @@
# cert-manager.io/v1/Certificate/ingress-nginx/ingress-nginx-admission-internal
! + one map entry added:
+   type: internal
```

THESE CHANGES ARE APPLIED BY `kapp` WITHOUT RECREATING THE OBJECTS, SO THEY SHOULD HAVE NO IMPACT.

### Breaking Changes 💔

[Upstream has introduced some breaking changes in v1.12.0](https://github.com/kubernetes/ingress-nginx/blob/main/changelog/controller-1.12.0.md), I don't think they have direct impact on how we use it, but it may affect some end-users of KFD.

Breaking changes that I think are relevant to our end-users:

> 
> - Remove `global-rate-limit` feature. This removes the following configuration options:
> 
>   - `global-rate-limit-memcached-host`
>   - `global-rate-limit-memcached-port`
>   - `global-rate-limit-memcached-connect-timeout`
>   - `global-rate-limit-memcached-max-idle-timeout`
>   - `global-rate-limit-memcached-pool-size`
>   - `global-rate-limit-status-code`
> 
>   It also removes the following annotations:
> 
>   - `global-rate-limit`
>   - `global-rate-limit-window`
>   - `global-rate-limit-key`
>   - `global-rate-limit-ignored-cidrs`
> 
> - Remove 3rd party lua plugin support. This removes the following configuration options:
> 
>   - `plugins`
> 
>   It also removes support for user provided Lua plugins in the `/etc/nginx/lua/plugins` directory.
> 

I mentioned these changes in the the `unreleased.md` file too.


### Tests performed 🧪

- [x] Tested that `dual` ingress is working with OIDC enabled on a KFD 1.32.0-rc.0 on -prem cluster.
- [x] Tested that `single` ingress is working with OIDC enabled on a KFD 1.32.0-rc.0 on-prem cluster.
- [x] Tested upgrade for `dual` from previous version on a KFD 1.31.0 on-prem cluster.
- [x] Tested upgrade for `single` from previous version on a KFD 1.31.0 on-prem cluster.

Note: needed images have already been synced.

### Future work 🔧

None.
