### PR TITLE
feat(external-dns): bump to v0.16.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ Kubernetes Fury Ingress provides the following packages:
 | [nginx](katalog/nginx)                        | `v1.12.0`  | The NGINX Ingress Controller for Kubernetes provides delivery services for Kubernetes applications.                           |
 | [dual-nginx](katalog/dual-nginx)              | `v1.12.0`  | It deploys two identical NGINX ingress controllers but with two different scopes: public/external and private/internal.       |
 | [cert-manager](katalog/cert-manager)          | `v1.16.1`  | cert-manager is a Kubernetes add-on to automate the management and issuance of TLS certificates from various issuing sources. |
-| [external-dns](katalog/external-dns)          | `v0.15.0`  | external-dns allows you to manage DNS records natively from Kubernetes.                                                       |
+| [external-dns](katalog/external-dns)          | `v0.16.1`  | external-dns allows you to manage DNS records natively from Kubernetes.                                                       |
 | [forecastle](katalog/forecastle)              | `v1.0.156` | Forecastle gives you access to a control panel where you can see your ingresses and access them on Kubernetes.                |
 | [aws-cert-manager](modules/aws-cert-manager/) | -          | Terraform modules for managing IAM permissions on AWS for cert-manager                                                        |
 | [aws-external-dns](modules/aws-external-dns/) | -          | Terraform modules for managing IAM permissions on AWS for external-dns                                                        |

--- a/docs/releases/unreleased.md
+++ b/docs/releases/unreleased.md
@@ -11,7 +11,7 @@ This release updates several packages to the latest versions available for new f
 | `aws-cert-manager` | N.A.                                                                                     |   `No update`    |
 | `aws-external-dns` | N.A.                                                                                     |   `No update`    |
 | `cert-manager`     | [`v1.16.1`](https://github.com/jetstack/cert-manager/releases/tag/v1.16.1)               |     `1.16.1`     |
-| `external-dns`     | [`v0.15.0`](https://github.com/kubernetes-sigs/external-dns/releases/tag/v0.15.0)        |     `0.15.0`     |
+| `external-dns`     | [`v0.16.1`](https://github.com/kubernetes-sigs/external-dns/releases/tag/v0.16.1)        |     `0.15.0`     |
 | `forecastle`       | [`v1.0.156`](https://github.com/stakater/Forecastle/releases/tag/v1.0.156)               |    `1.0.156`     |
 | `nginx`            | [`v1.12.0`](https://github.com/kubernetes/ingress-nginx/releases/tag/controller-v1.12.0) |     `1.11.3`     |
 
@@ -44,6 +44,10 @@ Upstream Ingress NGINX Controller has introduced some breaking changes in versio
   - `plugins`
 
   It also removes support for user provided Lua plugins in the `/etc/nginx/lua/plugins` directory.
+
+## external-dns
+
+A breaking change has been introduced in v0.16.0 for the Cloudflare provider, please see [this link](https://github.com/kubernetes-sigs/external-dns/issues/5166) for more details.
 
 ## Upgrade Guide 🦮
 

--- a/katalog/external-dns/README.md
+++ b/katalog/external-dns/README.md
@@ -7,11 +7,11 @@ ExternalDNS synchronizes exposed Kubernetes Services and Ingresses with DNS prov
 ## Requirements
 
 - Kubernetes >= `1.22.0`
-- Kustomize = `v3.5.3`
+- Kustomize >= `v5.6.0`
 
 ## Image repository and tag
 
-- ExternalDNS image: `k8s.gcr.io/external-dns/external-dns:v0.15.0`
+- ExternalDNS image: `k8s.gcr.io/external-dns/external-dns:v0.16.1`
 - ExternalDNS repo: [https://github.com/kubernetes-sigs/external-dns](https://github.com/kubernetes-sigs/external-dns)
 
 ## Deployment
@@ -35,9 +35,9 @@ resources:
 ```
 
 Refer to the Terraform module [aws-eternal-dns](../../modules/aws-external-dns) to create the
-IAM role and the required kustomize patches automatically. For now the only supported cloud provider is AWS with Route53.
+IAM role and the required Kustomize patches automatically. For now the only supported cloud provider is AWS with Route53.
 
-If still you want to create everything manually without using our Terraform Module, you need to patch the service accountas follows:
+If you want to still create everything manually without using our Terraform Module, you need to patch the service accounts follows:
 
 `sa-patch.yaml`
 ```yaml

--- a/katalog/external-dns/base/deploy.yml
+++ b/katalog/external-dns/base/deploy.yml
@@ -25,6 +25,7 @@ spec:
           args:
             - --source=service
             - --source=ingress
+            - --registry=txt
             - --provider=$(PROVIDER)
           ports:
             - name: metrics

--- a/katalog/external-dns/base/kustomization.yaml
+++ b/katalog/external-dns/base/kustomization.yaml
@@ -14,4 +14,4 @@ resources:
 images:
   - name: registry.k8s.io/external-dns/external-dns
     newName: registry.sighup.io/fury/external-dns/external-dns
-    newTag: v0.15.0
+    newTag: v0.16.1

--- a/modules/aws-external-dns/README.md
+++ b/modules/aws-external-dns/README.md
@@ -8,14 +8,14 @@ This terraform module provides an easy way to generate external-dns (public and 
 
 | Name      | Version   |
 | --------- | --------- |
-| terraform | >= 0.15.4 |
-| aws       | >= 3.37.0 |
+| terraform | ~> 1.3    |
+| aws       | >= 3.76.0 |
 
 ## Providers
 
 | Name | Version   |
 | ---- | --------- |
-| aws  | >= 3.37.0 |
+| aws  | >= 3.76.0 |
 
 ## Modules
 


### PR DESCRIPTION
### Summary 💡

- Bump external-dns to v0.16.0
- Update docs
- Added explicit `registry=txt`flag (txt is the default value anyway) being that it is included in upstream's manifests, so to reduce the diff.

Closes https://github.com/sighupio/product-management/issues/574

> [!NOTE]
> This PR is branched from #142, so 142 should be merged first and you will see changes from both PRs until 142 gets merged.


### Description 📝

See summary

### Breaking Changes 💔

Upstream introduced some breaking changes in v0.16.0 when using the CloudFlare provider:
https://github.com/kubernetes-sigs/external-dns/issues/5166

I don't think we have users using that provider, but I mentioned them anyway in the release notes.

### Tests performed 🧪

- [x] Tested that there are no differences between Kustomize v3 and v5
- [x] Tested that there are no deprecation warnings with kustomize v5
- [x] Tested deploy of the manifets on an on-prem cluster and that the pod runs.

Note: image has already been synced to our registry.

### Future work 🔧

Being that this is a very minor change, I left the test on an AWS cluster for later.

I propose to perform this tests together with the e2e tests on EKS, so to not create a test cluster to test only this minor update.
