### PR TITLE
feat(cert-manager): upgrade to v1.17.1

### DIFF
--- a/docs/releases/unreleased.md
+++ b/docs/releases/unreleased.md
@@ -10,7 +10,7 @@ This release updates several packages to the latest versions available for new f
 | ------------------ | ---------------------------------------------------------------------------------------- | :--------------: |
 | `aws-cert-manager` | N.A.                                                                                     |   `No update`    |
 | `aws-external-dns` | N.A.                                                                                     |   `No update`    |
-| `cert-manager`     | [`v1.16.1`](https://github.com/jetstack/cert-manager/releases/tag/v1.16.1)               |     `1.16.1`     |
+| `cert-manager`     | [`v1.17.1`](https://cert-manager.io/docs/releases/release-notes/release-notes-1.17/)     |     `1.16.1`     |
 | `external-dns`     | [`v0.16.1`](https://github.com/kubernetes-sigs/external-dns/releases/tag/v0.16.1)        |     `0.15.0`     |
 | `forecastle`       | [`v1.0.156`](https://github.com/stakater/Forecastle/releases/tag/v1.0.156)               |    `1.0.156`     |
 | `nginx`            | [`v1.12.0`](https://github.com/kubernetes/ingress-nginx/releases/tag/controller-v1.12.0) |     `1.11.3`     |

--- a/katalog/cert-manager/MAINTENANCE.md
+++ b/katalog/cert-manager/MAINTENANCE.md
@@ -36,7 +36,7 @@ References:
 - Specific version
 
   ```bash
-  curl --location --remote-name https://github.com/cert-manager/cert-manager/releases/download/v1.16.1/cert-manager.yaml
+  curl --location --remote-name https://github.com/cert-manager/cert-manager/releases/download/v1.17.1/cert-manager.yaml
   ```
 
 - Latest version
@@ -45,7 +45,7 @@ References:
   curl --location --remote-name https://github.com/cert-manager/cert-manager/releases/latest/download/cert-manager.yaml
   ```
 
-02. Split the absurdily large YAML into smaller pieces with the [kubernetes-split-yaml](github.com/mogensen/kubernetes-split-yaml) tool:
+02. Split the absurdly large YAML into smaller pieces with the [kubernetes-split-yaml](github.com/mogensen/kubernetes-split-yaml) tool:
 
     ```bash
     # Install the tool if you don't have it in your system
@@ -67,7 +67,7 @@ References:
 
     ```bash
     # Assuming PWD == the folder with the splitted yamls (generated)
-    # You might need to twek the order of the files concatenated.
+    # You might need to tweak the order of the files concatenated.
     mkdir cainjector
     mv cert-manager-cainjector* cainjector
     cd cainjector
@@ -227,11 +227,15 @@ References:
         cert-manager-cert-manager-tokenrequest-rb.yaml \
         cert-manager:leaderelection-rb.yaml \
         done
+
+        # WARNING: there are some patches in the kustomization.yaml file that
+        # rely on the arguments position in the array. Double-check that the args
+        # position does not need to be adjusted.
     ```
 
 03. Port the needed changes to the module's manifests.
 
-    - Remember to sync the new images to SIGHUP's registry. Images related in this projet are:
+    - Remember to sync the new images to SIGHUP's registry. Images related in this project are:
       - jetstack/cert-manager-cainjector
       - jetstack/cert-manager-acmesolver
       - jetstack/cert-manager-controller
@@ -249,10 +253,10 @@ References:
         patch: |-
         - op: replace
             path: /spec/template/spec/containers/0/args/6
-            value: --acme-http01-solver-image=registry.sighup.io/fury/cert-manager-acmesolver:v1.16.1
+            value: --acme-http01-solver-image=registry.sighup.io/fury/cert-manager-acmesolver:v1.17.1
 
     ```
 
 ## Dashboards
 
-The included Grafana dashbaord seems to be taken from here: <https://grafana.com/grafana/dashboards/11001-cert-manager/>. It has not been updated in a while.
+The included Grafana dashboard seems to be taken from here: <https://grafana.com/grafana/dashboards/11001-cert-manager/>. It has not been updated in a while.

--- a/katalog/cert-manager/README.md
+++ b/katalog/cert-manager/README.md
@@ -8,12 +8,12 @@ This package deploys cert-manager to be used with [Let's Encrypt](https://letsen
 
 ## Requirements
 
-- Kubernetes `1.23` -> `1.28`
-- Kustomize >= `v3.5.3`
+- Kubernetes `1.29` -> `1.32`
+- Kustomize >= `v5.6.0`
 
 ## Image repository and tag
 
-- Cert Manager image: `quay.io/jetstack/cert-manager-controller:v1.16.1`
+- Cert Manager image: `quay.io/jetstack/cert-manager-controller:v1.17.1`
 - Cert Manager repo: [https://github.com/jetstack/cert-manager](https://github.com/jetstack/cert-manager)
 - Cert Manager documentation: [https://cert-manager.io/docs/](https://cert-manager.io/docs/)
 

--- a/katalog/cert-manager/cainjector/deploy.yml
+++ b/katalog/cert-manager/cainjector/deploy.yml
@@ -11,7 +11,7 @@ metadata:
     app.kubernetes.io/name: cainjector
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/component: "cainjector"
-    app.kubernetes.io/version: "v1.16.1"
+    app.kubernetes.io/version: "v1.17.1"
 spec:
   replicas: 1
   selector:
@@ -26,7 +26,7 @@ spec:
         app.kubernetes.io/name: cainjector
         app.kubernetes.io/instance: cert-manager
         app.kubernetes.io/component: "cainjector"
-        app.kubernetes.io/version: "v1.16.1"
+        app.kubernetes.io/version: "v1.17.1"
       annotations:
         prometheus.io/path: "/metrics"
         prometheus.io/scrape: 'true'
@@ -40,7 +40,7 @@ spec:
           type: RuntimeDefault
       containers:
         - name: cert-manager-cainjector
-          image: "quay.io/jetstack/cert-manager-cainjector:v1.16.1"
+          image: "quay.io/jetstack/cert-manager-cainjector:v1.17.1"
           imagePullPolicy: Always
           args:
           - --v=2
@@ -77,7 +77,7 @@ metadata:
     app.kubernetes.io/name: cainjector
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/component: "cainjector"
-    app.kubernetes.io/version: "v1.16.1"
+    app.kubernetes.io/version: "v1.17.1"
 spec:
   type: ClusterIP
   ports:

--- a/katalog/cert-manager/cert-manager-controller/crd.yml
+++ b/katalog/cert-manager/cert-manager-controller/crd.yml
@@ -17,7 +17,7 @@ metadata:
     app.kubernetes.io/name: 'cert-manager'
     app.kubernetes.io/instance: 'cert-manager'
     # Generated labels
-    app.kubernetes.io/version: "v1.16.1"
+    app.kubernetes.io/version: "v1.17.1"
 spec:
   group: cert-manager.io
   names:
@@ -337,7 +337,7 @@ metadata:
     app.kubernetes.io/name: 'cert-manager'
     app.kubernetes.io/instance: 'cert-manager'
     # Generated labels
-    app.kubernetes.io/version: "v1.16.1"
+    app.kubernetes.io/version: "v1.17.1"
 spec:
   group: cert-manager.io
   names:
@@ -519,7 +519,6 @@ spec:
                       type: object
                       required:
                         - create
-                        - passwordSecretRef
                       properties:
                         alias:
                           description: |-
@@ -531,17 +530,25 @@ spec:
                             Create enables JKS keystore creation for the Certificate.
                             If true, a file named `keystore.jks` will be created in the target
                             Secret resource, encrypted using the password stored in
-                            `passwordSecretRef`.
+                            `passwordSecretRef` or `password`.
                             The keystore file will be updated immediately.
                             If the issuer provided a CA certificate, a file named `truststore.jks`
                             will also be created in the target Secret resource, encrypted using the
                             password stored in `passwordSecretRef`
                             containing the issuing Certificate Authority
                           type: boolean
+                        password:
+                          description: |-
+                            Password provides a literal password used to encrypt the JKS keystore.
+                            Mutually exclusive with passwordSecretRef.
+                            One of password or passwordSecretRef must provide a password with a non-zero length.
+                          type: string
                         passwordSecretRef:
                           description: |-
-                            PasswordSecretRef is a reference to a key in a Secret resource
+                            PasswordSecretRef is a reference to a non-empty key in a Secret resource
                             containing the password used to encrypt the JKS keystore.
+                            Mutually exclusive with password.
+                            One of password or passwordSecretRef must provide a password with a non-zero length.
                           type: object
                           required:
                             - name
@@ -564,24 +571,31 @@ spec:
                       type: object
                       required:
                         - create
-                        - passwordSecretRef
                       properties:
                         create:
                           description: |-
                             Create enables PKCS12 keystore creation for the Certificate.
                             If true, a file named `keystore.p12` will be created in the target
                             Secret resource, encrypted using the password stored in
-                            `passwordSecretRef`.
+                            `passwordSecretRef` or in `password`.
                             The keystore file will be updated immediately.
                             If the issuer provided a CA certificate, a file named `truststore.p12` will
                             also be created in the target Secret resource, encrypted using the
                             password stored in `passwordSecretRef` containing the issuing Certificate
                             Authority
                           type: boolean
+                        password:
+                          description: |-
+                            Password provides a literal password used to encrypt the PKCS#12 keystore.
+                            Mutually exclusive with passwordSecretRef.
+                            One of password or passwordSecretRef must provide a password with a non-zero length.
+                          type: string
                         passwordSecretRef:
                           description: |-
-                            PasswordSecretRef is a reference to a key in a Secret resource
-                            containing the password used to encrypt the PKCS12 keystore.
+                            PasswordSecretRef is a reference to a non-empty key in a Secret resource
+                            containing the password used to encrypt the PKCS#12 keystore.
+                            Mutually exclusive with password.
+                            One of password or passwordSecretRef must provide a password with a non-zero length.
                           type: object
                           required:
                             - name
@@ -1105,7 +1119,7 @@ metadata:
     app.kubernetes.io/name: 'cert-manager'
     app.kubernetes.io/instance: 'cert-manager'
     # Generated labels
-    app.kubernetes.io/version: "v1.16.1"
+    app.kubernetes.io/version: "v1.17.1"
 spec:
   group: acme.cert-manager.io
   names:
@@ -1380,6 +1394,9 @@ spec:
                                   description: |-
                                     resource ID of the managed identity, can not be used at the same time as clientID
                                     Cannot be used for Azure Managed Service Identity
+                                  type: string
+                                tenantID:
+                                  description: tenant ID of the managed identity, can not be used at the same time as resourceID
                                   type: string
                             resourceGroupName:
                               description: resource group the DNS zone is located in
@@ -4311,7 +4328,7 @@ metadata:
     app.kubernetes.io/name: 'cert-manager'
     app.kubernetes.io/instance: 'cert-manager'
     # Generated labels
-    app.kubernetes.io/version: "v1.16.1"
+    app.kubernetes.io/version: "v1.17.1"
 spec:
   group: cert-manager.io
   names:
@@ -4693,6 +4710,9 @@ spec:
                                         description: |-
                                           resource ID of the managed identity, can not be used at the same time as clientID
                                           Cannot be used for Azure Managed Service Identity
+                                        type: string
+                                      tenantID:
+                                        description: tenant ID of the managed identity, can not be used at the same time as resourceID
                                         type: string
                                   resourceGroupName:
                                     description: resource group the DNS zone is located in
@@ -8038,7 +8058,7 @@ metadata:
     app.kubernetes.io/instance: 'cert-manager'
     app.kubernetes.io/component: "crds"
     # Generated labels
-    app.kubernetes.io/version: "v1.16.1"
+    app.kubernetes.io/version: "v1.17.1"
 spec:
   group: cert-manager.io
   names:
@@ -8419,6 +8439,9 @@ spec:
                                         description: |-
                                           resource ID of the managed identity, can not be used at the same time as clientID
                                           Cannot be used for Azure Managed Service Identity
+                                        type: string
+                                      tenantID:
+                                        description: tenant ID of the managed identity, can not be used at the same time as resourceID
                                         type: string
                                   resourceGroupName:
                                     description: resource group the DNS zone is located in
@@ -11764,7 +11787,7 @@ metadata:
     app.kubernetes.io/instance: 'cert-manager'
     app.kubernetes.io/component: "crds"
     # Generated labels
-    app.kubernetes.io/version: "v1.16.1"
+    app.kubernetes.io/version: "v1.17.1"
 spec:
   group: acme.cert-manager.io
   names:

--- a/katalog/cert-manager/cert-manager-controller/deploy.yml
+++ b/katalog/cert-manager/cert-manager-controller/deploy.yml
@@ -12,7 +12,7 @@ metadata:
     app.kubernetes.io/name: cert-manager
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/component: "controller"
-    app.kubernetes.io/version: "v1.16.1"
+    app.kubernetes.io/version: "v1.17.1"
 spec:
   replicas: 1
   selector:
@@ -27,7 +27,7 @@ spec:
         app.kubernetes.io/name: cert-manager
         app.kubernetes.io/instance: cert-manager
         app.kubernetes.io/component: "controller"
-        app.kubernetes.io/version: "v1.16.1"
+        app.kubernetes.io/version: "v1.17.1"
       annotations:
         prometheus.io/path: "/metrics"
         prometheus.io/scrape: 'true'
@@ -41,16 +41,15 @@ spec:
           type: RuntimeDefault
       containers:
         - name: cert-manager-controller
-          image: "quay.io/jetstack/cert-manager-controller:v1.16.1"
+          image: "quay.io/jetstack/cert-manager-controller:v1.17.1"
           imagePullPolicy: IfNotPresent
+          # Maintainers: notice that we patch these args via kustomize
           args:
           - --v=2
           - --cluster-resource-namespace=$(POD_NAMESPACE)
-          - --leader-election-namespace=$(POD_NAMESPACE)
-          - --default-issuer-kind=ClusterIssuer
-          - --default-issuer-name=letsencrypt-prod
+          - --leader-election-namespace=kube-system
           - --max-concurrent-challenges=60
-          - --acme-http01-solver-image=quay.io/jetstack/cert-manager-acmesolver:v1.16.1
+          - --acme-http01-solver-image=quay.io/jetstack/cert-manager-acmesolver:v1.17.1
           ports:
           - containerPort: 9402
             name: http-metrics
@@ -69,10 +68,6 @@ spec:
             valueFrom:
               fieldRef:
                 fieldPath: metadata.namespace
-          resources:
-            requests:
-              cpu: 50m
-              memory: 50Mi
           # LivenessProbe settings are based on those used for the Kubernetes
           # controller-manager. See:
           # https://github.com/kubernetes/kubernetes/blob/806b30170c61a38fedd54cc9ede4cd6275a1ad3b/cmd/kubeadm/app/util/staticpod/utils.go#L241-L245
@@ -98,7 +93,7 @@ metadata:
     app.kubernetes.io/name: cert-manager
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/component: "controller"
-    app.kubernetes.io/version: "v1.16.1"
+    app.kubernetes.io/version: "v1.17.1"
 spec:
   type: ClusterIP
   ports:

--- a/katalog/cert-manager/cert-manager-controller/kustomization.yaml
+++ b/katalog/cert-manager/cert-manager-controller/kustomization.yaml
@@ -20,7 +20,7 @@ resources:
   - rbac.yml
   - sm.yml
 
-patchesJson6902:
+patches:
   - target:
       group: apps
       version: v1
@@ -28,5 +28,20 @@ patchesJson6902:
       name: cert-manager
     patch: |-
       - op: replace
-        path: /spec/template/spec/containers/0/args/6
-        value: --acme-http01-solver-image=registry.sighup.io/fury/jetstack/cert-manager-acmesolver:v1.16.1
+        path: /spec/template/spec/containers/0/args/2
+        value: --leader-election-namespace=$(POD_NAMESPACE)
+      - op: replace
+        path: /spec/template/spec/containers/0/args/4
+        value: --acme-http01-solver-image=registry.sighup.io/fury/jetstack/cert-manager-acmesolver:v1.17.1
+      - op: add
+        path: /spec/template/spec/containers/0/args/-
+        value: --default-issuer-kind=ClusterIssuer
+      - op: add
+        path: /spec/template/spec/containers/0/args/-
+        value: --default-issuer-name=letsencrypt-prod
+      - op: add
+        path: /spec/template/spec/containers/0/resources
+        value:
+            requests:
+              cpu: 50m
+              memory: 50Mi

--- a/katalog/cert-manager/cert-manager-controller/rbac.yml
+++ b/katalog/cert-manager/cert-manager-controller/rbac.yml
@@ -13,7 +13,7 @@ metadata:
     app.kubernetes.io/name: cert-manager
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/component: "controller"
-    app.kubernetes.io/version: "v1.16.1"
+    app.kubernetes.io/version: "v1.17.1"
 ---
 # Issuer controller role
 apiVersion: rbac.authorization.k8s.io/v1
@@ -25,7 +25,7 @@ metadata:
     app.kubernetes.io/name: cert-manager
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/component: "controller"
-    app.kubernetes.io/version: "v1.16.1"
+    app.kubernetes.io/version: "v1.17.1"
 rules:
   - apiGroups: ["cert-manager.io"]
     resources: ["issuers", "issuers/status"]
@@ -50,7 +50,7 @@ metadata:
     app.kubernetes.io/name: cert-manager
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/component: "controller"
-    app.kubernetes.io/version: "v1.16.1"
+    app.kubernetes.io/version: "v1.17.1"
 rules:
   - apiGroups: ["cert-manager.io"]
     resources: ["clusterissuers", "clusterissuers/status"]
@@ -75,7 +75,7 @@ metadata:
     app.kubernetes.io/name: cert-manager
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/component: "controller"
-    app.kubernetes.io/version: "v1.16.1"
+    app.kubernetes.io/version: "v1.17.1"
 rules:
   - apiGroups: ["cert-manager.io"]
     resources: ["certificates", "certificates/status", "certificaterequests", "certificaterequests/status"]
@@ -109,7 +109,7 @@ metadata:
     app.kubernetes.io/name: cert-manager
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/component: "controller"
-    app.kubernetes.io/version: "v1.16.1"
+    app.kubernetes.io/version: "v1.17.1"
 rules:
   - apiGroups: ["acme.cert-manager.io"]
     resources: ["orders", "orders/status"]
@@ -146,7 +146,7 @@ metadata:
     app.kubernetes.io/name: cert-manager
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/component: "controller"
-    app.kubernetes.io/version: "v1.16.1"
+    app.kubernetes.io/version: "v1.17.1"
 rules:
   # Use to update challenge resource status
   - apiGroups: ["acme.cert-manager.io"]
@@ -207,7 +207,7 @@ metadata:
     app.kubernetes.io/name: cert-manager
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/component: "cert-manager"
-    app.kubernetes.io/version: "v1.16.1"
+    app.kubernetes.io/version: "v1.17.1"
 rules:
   - apiGroups: ["certificates.k8s.io"]
     resources: ["certificatesigningrequests"]
@@ -233,7 +233,7 @@ metadata:
     app.kubernetes.io/name: cert-manager
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/component: "controller"
-    app.kubernetes.io/version: "v1.16.1"
+    app.kubernetes.io/version: "v1.17.1"
 rules:
   - apiGroups: ["cert-manager.io"]
     resources: ["certificates", "certificaterequests"]
@@ -269,7 +269,7 @@ metadata:
     app.kubernetes.io/name: cert-manager
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/component: "controller"
-    app.kubernetes.io/version: "v1.16.1"
+    app.kubernetes.io/version: "v1.17.1"
     rbac.authorization.k8s.io/aggregate-to-view: "true"
     rbac.authorization.k8s.io/aggregate-to-edit: "true"
     rbac.authorization.k8s.io/aggregate-to-admin: "true"
@@ -291,7 +291,7 @@ metadata:
     app.kubernetes.io/name: cert-manager
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/component: "controller"
-    app.kubernetes.io/version: "v1.16.1"
+    app.kubernetes.io/version: "v1.17.1"
     rbac.authorization.k8s.io/aggregate-to-edit: "true"
     rbac.authorization.k8s.io/aggregate-to-admin: "true"
 rules:
@@ -315,7 +315,7 @@ metadata:
     app.kubernetes.io/name: cert-manager
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/component: "cert-manager"
-    app.kubernetes.io/version: "v1.16.1"
+    app.kubernetes.io/version: "v1.17.1"
 rules:
   - apiGroups: ["cert-manager.io"]
     resources: ["signers"]
@@ -333,7 +333,7 @@ metadata:
     app.kubernetes.io/name: cert-manager
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/component: "controller"
-    app.kubernetes.io/version: "v1.16.1"
+    app.kubernetes.io/version: "v1.17.1"
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
@@ -351,7 +351,7 @@ metadata:
     app.kubernetes.io/name: cert-manager
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/component: "controller"
-    app.kubernetes.io/version: "v1.16.1"
+    app.kubernetes.io/version: "v1.17.1"
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
@@ -369,7 +369,7 @@ metadata:
     app.kubernetes.io/name: cert-manager
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/component: "controller"
-    app.kubernetes.io/version: "v1.16.1"
+    app.kubernetes.io/version: "v1.17.1"
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
@@ -387,7 +387,7 @@ metadata:
     app.kubernetes.io/name: cert-manager
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/component: "controller"
-    app.kubernetes.io/version: "v1.16.1"
+    app.kubernetes.io/version: "v1.17.1"
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
@@ -405,7 +405,7 @@ metadata:
     app.kubernetes.io/name: cert-manager
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/component: "controller"
-    app.kubernetes.io/version: "v1.16.1"
+    app.kubernetes.io/version: "v1.17.1"
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
@@ -423,7 +423,7 @@ metadata:
     app.kubernetes.io/name: cert-manager
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/component: "cert-manager"
-    app.kubernetes.io/version: "v1.16.1"
+    app.kubernetes.io/version: "v1.17.1"
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
@@ -442,7 +442,7 @@ metadata:
     app.kubernetes.io/name: cert-manager
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/component: "controller"
-    app.kubernetes.io/version: "v1.16.1"
+    app.kubernetes.io/version: "v1.17.1"
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
@@ -460,7 +460,7 @@ metadata:
     app.kubernetes.io/name: cert-manager
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/component: "cert-manager"
-    app.kubernetes.io/version: "v1.16.1"
+    app.kubernetes.io/version: "v1.17.1"
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
@@ -479,7 +479,7 @@ metadata:
     app.kubernetes.io/name: cert-manager
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/component: "controller"
-    app.kubernetes.io/version: "v1.16.1"
+    app.kubernetes.io/version: "v1.17.1"
 rules:
   - apiGroups: [""]
     resources: ["serviceaccounts/token"]
@@ -496,7 +496,7 @@ metadata:
     app.kubernetes.io/name: cert-manager
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/component: "controller"
-    app.kubernetes.io/version: "v1.16.1"
+    app.kubernetes.io/version: "v1.17.1"
 rules:
   - apiGroups: ["coordination.k8s.io"]
     resources: ["leases"]
@@ -522,7 +522,7 @@ metadata:
     app.kubernetes.io/name: cert-manager
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/component: "controller"
-    app.kubernetes.io/version: "v1.16.1"
+    app.kubernetes.io/version: "v1.17.1"
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
@@ -540,7 +540,7 @@ metadata:
     app.kubernetes.io/name: cert-manager
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/component: "controller"
-    app.kubernetes.io/version: "v1.16.1"
+    app.kubernetes.io/version: "v1.17.1"
     rbac.authorization.k8s.io/aggregate-to-cluster-reader: "true"
 rules:
   - apiGroups: ["cert-manager.io"]
@@ -558,7 +558,7 @@ metadata:
     app.kubernetes.io/name: cert-manager
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/component: "controller"
-    app.kubernetes.io/version: "v1.16.1"
+    app.kubernetes.io/version: "v1.17.1"
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role

--- a/katalog/cert-manager/webhook/deploy.yml
+++ b/katalog/cert-manager/webhook/deploy.yml
@@ -12,7 +12,7 @@ metadata:
     app.kubernetes.io/name: webhook
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/component: "webhook"
-    app.kubernetes.io/version: "v1.16.1"
+    app.kubernetes.io/version: "v1.17.1"
 spec:
   replicas: 1
   selector:
@@ -27,7 +27,7 @@ spec:
         app.kubernetes.io/name: webhook
         app.kubernetes.io/instance: cert-manager
         app.kubernetes.io/component: "webhook"
-        app.kubernetes.io/version: "v1.16.1"
+        app.kubernetes.io/version: "v1.17.1"
       annotations:
         prometheus.io/path: "/metrics"
         prometheus.io/scrape: 'true'
@@ -41,7 +41,7 @@ spec:
           type: RuntimeDefault
       containers:
         - name: cert-manager-webhook
-          image: "quay.io/jetstack/cert-manager-webhook:v1.16.1"
+          image: "quay.io/jetstack/cert-manager-webhook:v1.17.1"
           imagePullPolicy: IfNotPresent
           args:
           - --v=2
@@ -109,7 +109,7 @@ metadata:
     app.kubernetes.io/name: webhook
     app.kubernetes.io/instance: cert-manager
     app.kubernetes.io/component: "webhook"
-    app.kubernetes.io/version: "v1.16.1"
+    app.kubernetes.io/version: "v1.17.1"
 spec:
   type: ClusterIP
   ports:


### PR DESCRIPTION
### Summary 💡

- Bump cert-manager to v1.17.1
- Move customizations applied directly to the manifests to Kustomize patches for better maintainability
- Update docs
- Updated kustomize projects to use v5-compatible features.
- New images have already been synced to SIGHUP's registry.

Fixes https://github.com/sighupio/product-management/issues/572

> [!NOTE]
> This PR is based on #143. You will see changes introduced by both PRs until 143 gets merged.

### Description 📝

See summary.

### Breaking Changes 💔

None

### Tests performed 🧪

- [x] Tested a clean installation of this changes on a 1.32 cluster.
- [x] Tested an upgrade from the previous version to this one on a 1.32 cluster and followed the [verify installation instructions](https://cert-manager.io/docs/installation/kubectl/#2-optional-end-to-end-verify-the-installation) on the docs. everything OK.
- [x] Verified that the kustomize build with v5 is consistent with v3

### Future work 🔧

I feel like the maintenance of this package could be more automated. It may be worthy to spend some time to create some scripts.

Also, there's a mix of usage of the `kube-system` and `cert-manager` namespaces that creates some confusion and the docs may be outdated regarding that.