### PR TITLE
feat: prepare for releasing v4.0.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 </h1>
 <!-- markdownlint-enable MD033 -->
 
-![Release](https://img.shields.io/badge/Latest%20Release-v3.0.1-blue)
+![Release](https://img.shields.io/badge/Latest%20Release-v4.0.0-blue)
 ![License](https://img.shields.io/github/license/sighupio/fury-kubernetes-ingress?label=License)
 ![Slack](https://img.shields.io/badge/slack-@kubernetes/fury-yellow.svg?logo=slack&label=Slack)
 
@@ -51,10 +51,10 @@ Kubernetes Fury Ingress provides the following packages:
 
 | Kubernetes Version |   Compatibility    | Notes           |
 | ------------------ | :----------------: | --------------- |
-| `1.28.x`           | :white_check_mark: | No known issues |
 | `1.29.x`           | :white_check_mark: | No known issues |
 | `1.30.x`           | :white_check_mark: | No known issues |
 | `1.31.x`           | :white_check_mark: | No known issues |
+| `1.32.x`           | :white_check_mark: | No known issues |
 
 Check the [compatibility matrix][compatibility-matrix] for additional information on previous releases of the module.
 
@@ -123,9 +123,9 @@ To deploy the `cert-manager` package:
 ```yaml
 bases:
   - name: ingress/dual-nginx
-    version: "v3.0.1"
+    version: "v4.0.0"
   - name: ingress/cert-manager
-    version: "v3.0.1"
+    version: "v4.0.0"
 ```
 
 2. Execute `furyctl vendor -H` to download the packages
@@ -184,7 +184,7 @@ Single Ingress:
 ```yaml
 bases:
   - name: ingress/nginx
-    version: "v3.0.1"
+    version: "v4.0.0"
 ```
 
 Dual Ingress:
@@ -194,9 +194,9 @@ Dual Ingress:
 ```yaml
 bases:
   - name: ingress/nginx
-    version: "v3.0.1"
+    version: "v4.0.0"
   - name: ingress/dual-nginx
-    version: "v3.0.1"
+    version: "v4.0.0"
 ```
 
 > See `furyctl` [documentation][furyctl-repo] for additional details about `Furyfile.yml` format.
@@ -268,11 +268,11 @@ To deploy the `forecastle` package:
 ```yaml
 bases:
   - name: ingress/dual-nginx
-    version: "v3.0.1"
+    version: "v4.0.0"
   - name: ingress/cert-manager
-    version: "v3.0.1"
+    version: "v4.0.0"
   - name: ingress/forecastle
-    version: "v3.0.1"
+    version: "v4.0.0"
 ```
 
 2. Execute `furyctl legacy vendor -H` to download the packages

--- a/docs/COMPATIBILITY_MATRIX.md
+++ b/docs/COMPATIBILITY_MATRIX.md
@@ -1,16 +1,17 @@
 # Compatibility Matrix
 
-| Module Version / Kubernetes Version | 1.23.X             | 1.24.X             | 1.25.X             | 1.26.X             | 1.27.X             | 1.28.X             | 1.29.X             | 1.30.X             | 1.31.X             |
-|-------------------------------------|--------------------|--------------------|--------------------|--------------------|--------------------|--------------------|--------------------|--------------------|--------------------|
-| v2.0.0                              | :white_check_mark: | :white_check_mark: | :white_check_mark: |                    |                    |                    |                    |                    |                    |
-| v2.1.0                              |                    | :white_check_mark: | :white_check_mark: | :white_check_mark: |                    |                    |                    |                    |                    |
-| v2.2.0                              |                    |                    | :white_check_mark: | :white_check_mark: | :white_check_mark: |                    |                    |                    |                    |
-| v2.3.0                              |                    |                    |                    | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: |
-| v2.3.1                              |                    |                    |                    | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: |
-| v2.3.2                              |                    |                    |                    | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: |
-| v2.3.3                              |                    |                    |                    | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: |
-| v3.0.0                              |                    |                    |                    |                    | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: |
-| v3.0.1                              |                    |                    |                    |                    |                    | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: |
+| Module Version / Kubernetes Version | 1.23.X             | 1.24.X             | 1.25.X             | 1.26.X             | 1.27.X             | 1.28.X             | 1.29.X             | 1.30.X             | 1.31.X             | 1.32.X             |
+|-------------------------------------|--------------------|--------------------|--------------------|--------------------|--------------------|--------------------|--------------------|--------------------|--------------------|--------------------|
+| v2.0.0                              | :white_check_mark: | :white_check_mark: | :white_check_mark: |                    |                    |                    |                    |                    |                    |                    |
+| v2.1.0                              |                    | :white_check_mark: | :white_check_mark: | :white_check_mark: |                    |                    |                    |                    |                    |                    |
+| v2.2.0                              |                    |                    | :white_check_mark: | :white_check_mark: | :white_check_mark: |                    |                    |                    |                    |                    |
+| v2.3.0                              |                    |                    |                    | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: |
+| v2.3.1                              |                    |                    |                    | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: |
+| v2.3.2                              |                    |                    |                    | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: |
+| v2.3.3                              |                    |                    |                    | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: |
+| v3.0.0                              |                    |                    |                    |                    | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: |
+| v3.0.1                              |                    |                    |                    |                    |                    | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: |
+| v4.0.0                              |                    |                    |                    |                    |                    |                    |                    | :white_check_mark: | :white_check_mark: | :white_check_mark: |
 
 :white_check_mark: Compatible
 

--- a/docs/releases/v4.0.0.md
+++ b/docs/releases/v4.0.0.md
@@ -1,8 +1,8 @@
-# Kubernetes Fury Ingress Core Module Release TBD
+# Kubernetes Fury Ingress Core Module Release 4.0.0
 
 Welcome to the latest release of `Ingress` module of [`Kubernetes Fury Distribution`](https://github.com/sighupio/fury-distribution) maintained by team SIGHUP.
 
-This release updates several packages to the latest versions available for new features, bug fixes and improved security, it also introduces compatibility with Kubernetes 1.32.
+This release updates several packages to the latest versions available for new features, bug fixes and improved security, it also drops compatibility with Kubernetes 1.28 and introduces compatibility with Kubernetes 1.32.
 
 ## Component versions 🚢
 
@@ -63,7 +63,7 @@ A breaking change has been introduced in v0.16.0 for the Cloudflare provider, pl
 
 ### Process
 
-To upgrade this core module from `v3.0.1` to `vTBD`, you need to download this new version and apply the instructions below.
+To upgrade this core module from `v3.0.1` to `v4.0.0`, you need to download this new version and apply the instructions below.
 
 ```bash
 kustomize build <your-project-path> | kubectl apply -f - --server-side

--- a/katalog/cert-manager/README.md
+++ b/katalog/cert-manager/README.md
@@ -33,9 +33,9 @@ To deploy the `cert-manager` package:
 ```yaml
 resources:
   - name: ingress/dual-nginx
-    version: "v3.0.1"
+    version: "v4.0.0"
   - name: ingress/cert-manager
-    version: "v3.0.1"
+    version: "v4.0.0"
 ```
 
 2. Execute `furyctl legacy vendor -H` to download the packages

--- a/katalog/dual-nginx/README.md
+++ b/katalog/dual-nginx/README.md
@@ -33,9 +33,9 @@ Ingress NGINX Double is deployed with the following default configuration:
 ```yaml
 bases:
   - name: ingress/nginx
-    version: "v3.0.1"
+    version: "v4.0.0
   - name: ingress/dual-nginx
-    version: "v3.0.1"
+    version: "v4.0.0
 ```
 
 > See `furyctl` [documentation][furyctl-repo] for additional details about `Furyfile.yml` format.

--- a/katalog/nginx/README.md
+++ b/katalog/nginx/README.md
@@ -33,7 +33,7 @@ Ingress NGINX single is deployed with the following default configuration:
 ```yaml
 bases:
   - name: ingress/nginx
-    version: "v3.0.1"
+    version: "v4.0.0
 ```
 
 > See `furyctl` [documentation][furyctl-repo] for additional details about `Furyfile.yml` format.


### PR DESCRIPTION
### Summary 💡

Update docs for releasing v4.0.0

closes https://github.com/sighupio/product-management/issues/577


### Description 📝

Documentation for releasing v4.0.0 of the module, I decided to bump a major being that are user-facing breaking changes introduced.

The breaking changes don't change the deployment mode nor need extra care, there are some features that have been dropped by upstream that we are not directly using but our users could be.

### Breaking Changes 💔

Non by this PR.

### Tests performed 🧪

N.A.

### Future work 🔧

N.A.