### PR TITLE
feat(drone): add 1.34 e2e tests

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -62,7 +62,7 @@ steps:
       - render
     commands:
       # we use --ignore-deprecations because we don't want the CI to fail when the API has not been removed yet.
-      - /pluto detect $${KUBERNETES_MANIFESTS} --ignore-deprecations --target-versions=k8s=v1.33.0
+      - /pluto detect $${KUBERNETES_MANIFESTS} --ignore-deprecations --target-versions=k8s=v1.34.0
     environment:
       KUBERNETES_MANIFESTS: cert-manager.yml
 
@@ -629,6 +629,113 @@ steps:
         - failure
 
 ---
+name: E2E Tests on kind clusters version 1.34.0
+kind: pipeline
+type: docker
+platform:
+  os: linux
+  arch: amd64
+depends_on:
+  - policeman
+clone:
+  depth: 1
+trigger:
+  ref:
+    include:
+      - refs/tags/**
+volumes:
+  - name: dockersock
+    host:
+      path: /var/run/docker.sock
+  - name: mise-cache
+    host:
+      path: /root/mise_data_dir
+steps:
+  - name: Generate Kind Config file
+    image: alpine:latest
+    pull: always
+    commands:
+      - sh ./katalog/tests/kind/generate-template.sh 1.34.0
+
+  - name: Create Kind Cluster
+    image: quay.io/sighup/mise:v2025.4.4
+    pull: always
+    environment:
+      MISE_DATA_DIR: /mise-data
+      MISE_OVERRIDE_CONFIG_FILENAMES: "mise.ci.toml"
+      KIND_VERSION: "0.29.0"
+      KUBECTL_VERSION: "1.34.0"
+      CLUSTER_NAME: ${DRONE_REPO_NAME}-${DRONE_BUILD_NUMBER}-1.34.0
+      GITHUB_TOKEN:
+        from_secret: github_token
+    volumes:
+      - name: dockersock
+        path: /var/run/docker.sock
+      - name: mise-cache
+        path: /mise-data
+    commands:
+      - |
+        mise use kind@$${KIND_VERSION} kubectl@$${KUBECTL_VERSION}
+        eval "$(mise activate bash --shims)"
+      - kind create cluster --config ./config-$${CLUSTER_NAME}.yaml
+      - kind get kubeconfig --name $${CLUSTER_NAME} > ./kubeconfig-$${CLUSTER_NAME}
+    depends_on:
+      - Generate Kind Config file
+
+  - name: End-to-End Tests
+    image: quay.io/sighup/mise:v2025.4.4
+    pull: always
+    network_mode: host
+    environment:
+      MISE_DATA_DIR: /mise-data
+      MISE_OVERRIDE_CONFIG_FILENAMES: "mise.ci.toml"
+      KUBECTL_VERSION: "1.34.0"
+      KUBECONFIG: ./kubeconfig-${DRONE_REPO_NAME}-${DRONE_BUILD_NUMBER}-1.34.0
+      CLUSTER_NAME: ${DRONE_REPO_NAME}-${DRONE_BUILD_NUMBER}-1.34.0
+      GITHUB_TOKEN:
+        from_secret: github_token
+    volumes:
+      - name: mise-cache
+        path: /mise-data
+    commands:
+      - |
+        mise use bats@1.1.0 kubectl@$${KUBECTL_VERSION} kustomize@5.6.0
+        eval "$(mise activate bash --shims)"
+      - . ./env-$${CLUSTER_NAME}.env
+      - until kubectl get serviceaccount default > /dev/null 2>&1; do echo "waiting for control-plane" && sleep 1; done
+      - bats -t ./katalog/tests/tests.bats
+    depends_on:
+      - Create Kind Cluster
+
+  - name: Destroy Kind Cluster
+    image: quay.io/sighup/mise:v2025.4.4
+    pull: always
+    environment:
+      MISE_DATA_DIR: /mise-data
+      MISE_OVERRIDE_CONFIG_FILENAMES: "mise.ci.toml"
+      KIND_VERSION: "0.29.0"
+      KUBECTL_VERSION: "1.34.0"
+      CLUSTER_NAME: ${DRONE_REPO_NAME}-${DRONE_BUILD_NUMBER}-1.34.0
+      GITHUB_TOKEN:
+        from_secret: github_token
+    volumes:
+      - name: dockersock
+        path: /var/run/docker.sock
+      - name: mise-cache
+        path: /mise-data
+    commands:
+      - |
+        mise use kind@$${KIND_VERSION} kubectl@$${KUBECTL_VERSION}
+        eval "$(mise activate bash --shims)"
+      - "kind delete cluster --name $${CLUSTER_NAME} || true"
+    depends_on:
+      - End-to-End Tests
+    when:
+      status:
+        - success
+        - failure
+
+---
 name: release
 kind: pipeline
 type: docker
@@ -640,6 +747,7 @@ depends_on:
   - E2E Tests on kind clusters version 1.31.1
   - E2E Tests on kind clusters version 1.32.2
   - E2E Tests on kind clusters version 1.33.0
+  - E2E Tests on kind clusters version 1.34.0
 platform:
   os: linux
   arch: amd64


### PR DESCRIPTION
### Summary 💡                                                                                                                                                                                                                            
                                                                                                                                                                                                                                            
Added Kubernetes 1.34.0 e2e tests to the Drone CI pipeline, aligning with the v5.0.0 release notes that claim 1.34.x support. The new pipeline uses Kind 0.29.0 and kubectl 1.34.0, matching the versions already used in module-networking. The policeman pluto check was also bumped to target k8s v1.34.0, and the release pipeline now depends on all six e2e test pipelines.

### Breaking Changes 💔

None.

### Tests performed 🧪

- [x] e2e test passing