### PR TITLE
feat: update nginx ingress controller to v1.15.1

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -521,6 +521,113 @@ steps:
         - failure
 
 ---
+name: E2E Tests on kind clusters version 1.35.0
+kind: pipeline
+type: docker
+platform:
+  os: linux
+  arch: amd64
+depends_on:
+  - policeman
+clone:
+  depth: 1
+trigger:
+  ref:
+    include:
+      - refs/tags/**
+volumes:
+  - name: dockersock
+    host:
+      path: /var/run/docker.sock
+  - name: mise-cache
+    host:
+      path: /root/mise_data_dir
+steps:
+  - name: Generate Kind Config file
+    image: alpine:latest
+    pull: always
+    commands:
+      - sh ./katalog/tests/kind/generate-template.sh 1.35.0
+
+  - name: Create Kind Cluster
+    image: quay.io/sighup/mise:v2025.4.4
+    pull: always
+    environment:
+      MISE_DATA_DIR: /mise-data
+      MISE_OVERRIDE_CONFIG_FILENAMES: "mise.ci.toml"
+      KIND_VERSION: "0.31.0"
+      KUBECTL_VERSION: "1.35.0"
+      CLUSTER_NAME: ${DRONE_REPO_NAME}-${DRONE_BUILD_NUMBER}-1.35.0
+      GITHUB_TOKEN:
+        from_secret: github_token
+    volumes:
+      - name: dockersock
+        path: /var/run/docker.sock
+      - name: mise-cache
+        path: /mise-data
+    commands:
+      - |
+        mise use kind@$${KIND_VERSION} kubectl@$${KUBECTL_VERSION}
+        eval "$(mise activate bash --shims)"
+      - kind create cluster --config ./config-$${CLUSTER_NAME}.yaml
+      - kind get kubeconfig --name $${CLUSTER_NAME} > ./kubeconfig-$${CLUSTER_NAME}
+    depends_on:
+      - Generate Kind Config file
+
+  - name: End-to-End Tests
+    image: quay.io/sighup/mise:v2025.4.4
+    pull: always
+    network_mode: host
+    environment:
+      MISE_DATA_DIR: /mise-data
+      MISE_OVERRIDE_CONFIG_FILENAMES: "mise.ci.toml"
+      KUBECTL_VERSION: "1.35.0"
+      KUBECONFIG: ./kubeconfig-${DRONE_REPO_NAME}-${DRONE_BUILD_NUMBER}-1.35.0
+      CLUSTER_NAME: ${DRONE_REPO_NAME}-${DRONE_BUILD_NUMBER}-1.35.0
+      GITHUB_TOKEN:
+        from_secret: github_token
+    volumes:
+      - name: mise-cache
+        path: /mise-data
+    commands:
+      - |
+        mise use bats@1.1.0 kubectl@$${KUBECTL_VERSION} kustomize@5.6.0
+        eval "$(mise activate bash --shims)"
+      - . ./env-$${CLUSTER_NAME}.env
+      - until kubectl get serviceaccount default > /dev/null 2>&1; do echo "waiting for control-plane" && sleep 1; done
+      - bats -t ./katalog/tests/tests.bats
+    depends_on:
+      - Create Kind Cluster
+
+  - name: Destroy Kind Cluster
+    image: quay.io/sighup/mise:v2025.4.4
+    pull: always
+    environment:
+      MISE_DATA_DIR: /mise-data
+      MISE_OVERRIDE_CONFIG_FILENAMES: "mise.ci.toml"
+      KIND_VERSION: "0.31.0"
+      KUBECTL_VERSION: "1.35.0"
+      CLUSTER_NAME: ${DRONE_REPO_NAME}-${DRONE_BUILD_NUMBER}-1.35.0
+      GITHUB_TOKEN:
+        from_secret: github_token
+    volumes:
+      - name: dockersock
+        path: /var/run/docker.sock
+      - name: mise-cache
+        path: /mise-data
+    commands:
+      - |
+        mise use kind@$${KIND_VERSION} kubectl@$${KUBECTL_VERSION}
+        eval "$(mise activate bash --shims)"
+      - "kind delete cluster --name $${CLUSTER_NAME} || true"
+    depends_on:
+      - End-to-End Tests
+    when:
+      status:
+        - success
+        - failure
+
+---
 name: release
 kind: pipeline
 type: docker
@@ -531,6 +638,7 @@ depends_on:
   - E2E Tests on kind clusters version 1.32.2
   - E2E Tests on kind clusters version 1.33.0
   - E2E Tests on kind clusters version 1.34.0
+  - E2E Tests on kind clusters version 1.35.0
 platform:
   os: linux
   arch: amd64

--- a/README.md
+++ b/README.md
@@ -43,8 +43,8 @@ Ingress Module provides the following packages:
 
 | Package                                       | Version    | Description                                                                                                                   |
 | --------------------------------------------- | ---------- | ----------------------------------------------------------------------------------------------------------------------------- |
-| [nginx](katalog/nginx)                        | `v1.14.3`  | The NGINX Ingress Controller for Kubernetes provides delivery services for Kubernetes applications.                           |
-| [dual-nginx](katalog/dual-nginx)              | `v1.14.3`  | It deploys two identical NGINX ingress controllers but with two different scopes: public/external and private/internal.       |
+| [nginx](katalog/nginx)                        | `v1.15.1`  | The NGINX Ingress Controller for Kubernetes provides delivery services for Kubernetes applications.                           |
+| [dual-nginx](katalog/dual-nginx)              | `v1.15.1`  | It deploys two identical NGINX ingress controllers but with two different scopes: public/external and private/internal.       |
 | [cert-manager](katalog/cert-manager)          | `v1.19.2`  | cert-manager is a Kubernetes add-on to automate the management and issuance of TLS certificates from various issuing sources. |
 | [external-dns](katalog/external-dns)          | `v0.20.0`  | external-dns allows you to manage DNS records natively from Kubernetes.                                                       |
 | [haproxy](katalog/haproxy)                    | `v3.2.4`   | The HAProxy Ingress Controller for Kubernetes, supporting single and dual deployment modes.                                   |
@@ -61,6 +61,7 @@ Ingress Module provides the following packages:
 | `1.32.x`           | :white_check_mark: | No known issues |
 | `1.33.x`           | :white_check_mark: | No known issues |
 | `1.34.x`           | :white_check_mark: | No known issues |
+| `1.35.x`           | :white_check_mark: | No known issues |
 
 Check the [compatibility matrix][compatibility-matrix] for additional information on previous releases of the module.
 

--- a/docs/releases/unreleased.md
+++ b/docs/releases/unreleased.md
@@ -2,9 +2,10 @@
 
 Welcome to the latest release of `Ingress` module of [`SIGHUP Distribution`](https://github.com/sighupio/fury-distribution) maintained by team SIGHUP.
 
-This release is for: CVSS Rating: 8.8 (Medium) CVSS:3.1/AV:N/AC:L/PR:L/UI:N/S:U/C:H/I:H/A:H
+This release addresses two security vulnerabilities in ingress-nginx where a combination of Ingress annotations can be used to inject configuration into nginx, leading to arbitrary code execution in the context of the ingress-nginx controller and disclosure of Secrets accessible to the controller.
 
-A security issue was discovered in ingress-nginx where a combination of Ingress annotations can be used to inject configuration into nginx. This can lead to arbitrary code execution in the context of the ingress-nginx controller, and disclosure of Secrets accessible to the controller.
+- [CVE-2026-4342](https://groups.google.com/g/kubernetes-security-announce/c/E9bLHAD6-eg): ingress-nginx comment-based nginx configuration injection (CVSS 8.8 - CVSS:3.1/AV:N/AC:L/PR:L/UI:N/S:U/C:H/I:H/A:H)
+- [CVE-2026-3288](https://groups.google.com/g/kubernetes-security-announce/c/hIAkgZb8MJ0): ingress-nginx rewrite-target nginx configuration injection (CVSS 8.8 - CVSS:3.1/AV:N/AC:L/PR:L/UI:N/S:U/C:H/I:H/A:H)
 
 ## Component Images 🚢
 

--- a/docs/releases/unreleased.md
+++ b/docs/releases/unreleased.md
@@ -2,18 +2,31 @@
 
 Welcome to the latest release of `Ingress` module of [`SIGHUP Distribution`](https://github.com/sighupio/fury-distribution) maintained by team SIGHUP.
 
-## Component versions 🚢
+This release is for: CVSS Rating: 8.8 (Medium) CVSS:3.1/AV:N/AC:L/PR:L/UI:N/S:U/C:H/I:H/A:H
 
-| Component          | Supported Version | Previous Version |
-| ------------------ | ----------------- | :--------------: |
+A security issue was discovered in ingress-nginx where a combination of Ingress annotations can be used to inject configuration into nginx. This can lead to arbitrary code execution in the context of the ingress-nginx controller, and disclosure of Secrets accessible to the controller.
 
-## New features 🎉
+## Component Images 🚢
 
-## Breaking changes 💔
+| Component          | Supported Version                                                                        | Previous Version |
+| ------------------ | ---------------------------------------------------------------------------------------- | :--------------: |
+| `aws-cert-manager` | N.A.                                                                                     |   `No update`    |
+| `aws-external-dns` | N.A.                                                                                     |   `No update`    |
+| `cert-manager`     | [`v1.19.2`](https://cert-manager.io/docs/releases/release-notes/release-notes-1.19/)     |    `No update`     |
+| `dual-nginx`       | [`v1.14.3`](https://github.com/kubernetes/ingress-nginx/releases/tag/controller-v1.14.3) |    `No update`     |
+| `external-dns`     | [`v0.20.0`](https://github.com/kubernetes-sigs/external-dns/releases/tag/v0.20.0)        |    `No update`     |
+| `forecastle`       | [`v1.0.159`](https://github.com/stakater/Forecastle/releases/tag/v1.0.159)               |    `No update`    |
+| `haproxy`          | [`v3.2.4`](https://github.com/haproxytech/kubernetes-ingress/releases/tag/v3.2.4)        |      `No update`       |
+| `nginx`            | [`v1.15.1`](https://github.com/kubernetes/ingress-nginx/releases/tag/controller-v1.15.1) |    `v1.14.3`     |
 
-## Kubernetes support 🚢
+> Please refer the individual release notes to get a more detailed information on each release.
 
-| Kubernetes Version |   Compatibility    | Notes           |
-| ------------------ | :----------------: | --------------- |
+## Update Guide 🦮
 
-## Upgrade Guide 🦮
+### Process
+
+To upgrade this core module from `v5.0.0` to `v5.0.1`, you need to download this new version, and apply the instructions below.
+
+```bash
+kustomize build <your-project-path> | kubectl apply -f -
+```

--- a/katalog/dual-nginx/README.md
+++ b/katalog/dual-nginx/README.md
@@ -12,7 +12,7 @@ Ingress NGINX is an Ingress Controller for [NGINX][nginx-page] webserver and rev
 
 ## Image repository and tag
 
-- Ingress NGINX image: `k8s.gcr.io/ingress-nginx/controller:v1.14.3`
+- Ingress NGINX image: `k8s.gcr.io/ingress-nginx/controller:v1.15.1`
 - Ingress NGINX repo: [https://github.com/kubernetes/ingress-nginx](https://github.com/kubernetes/ingress-nginx)
 
 ## Configuration

--- a/katalog/nginx/MAINTENANCE.md
+++ b/katalog/nginx/MAINTENANCE.md
@@ -1,8 +1,8 @@
 # Ingress NGINX controller package maintenance guide
 
-**Current Version**: v1.14.3 (Helm Chart 4.14.3)
+**Current Version**: v1.15.1 (Helm Chart 4.15.1)
 **Previous Version**: v1.14.1 (Helm Chart 4.14.1)
-**Last Updated**: February 2026
+**Last Updated**: April 2026
 
 To update Ingress NGINX controller, follow the next steps (or update and use the [upgrade.sh](./upgrade.sh) script to automate it):
 

--- a/katalog/nginx/MAINTENANCE.values.yml
+++ b/katalog/nginx/MAINTENANCE.values.yml
@@ -10,7 +10,7 @@ controller:
   image:
     registry: registry.sighup.io
     image: fury/ingress-nginx/controller
-    tag: "v1.14.3"
+    tag: "v1.15.1"
     pullPolicy: Always
     digest: ""
   containerPort:

--- a/katalog/nginx/README.md
+++ b/katalog/nginx/README.md
@@ -12,7 +12,7 @@ Ingress NGINX is an Ingress Controller for [NGINX][nginx-page] web server and re
 
 ## Image repository and tag
 
-- Ingress NGINX image: `k8s.gcr.io/ingress-nginx/controller:v1.14.3`
+- Ingress NGINX image: `k8s.gcr.io/ingress-nginx/controller:v1.15.1`
 - Ingress NGINX repo: [https://github.com/kubernetes/ingress-nginx](https://github.com/kubernetes/ingress-nginx)
 
 ## Configuration

--- a/katalog/nginx/bases/configs/ClusterRole-ingress-nginx.yml
+++ b/katalog/nginx/bases/configs/ClusterRole-ingress-nginx.yml
@@ -8,10 +8,10 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   labels:
-    helm.sh/chart: ingress-nginx-4.14.3
+    helm.sh/chart: ingress-nginx-4.15.1
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/version: "1.14.3"
+    app.kubernetes.io/version: "1.15.1"
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/managed-by: Helm
   name: ingress-nginx

--- a/katalog/nginx/bases/configs/ClusterRoleBinding-ingress-nginx.yml
+++ b/katalog/nginx/bases/configs/ClusterRoleBinding-ingress-nginx.yml
@@ -8,10 +8,10 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   labels:
-    helm.sh/chart: ingress-nginx-4.14.3
+    helm.sh/chart: ingress-nginx-4.15.1
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/version: "1.14.3"
+    app.kubernetes.io/version: "1.15.1"
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/managed-by: Helm
   name: ingress-nginx

--- a/katalog/nginx/bases/configs/PrometheusRule-ingress-nginx-controller.yml
+++ b/katalog/nginx/bases/configs/PrometheusRule-ingress-nginx-controller.yml
@@ -10,10 +10,10 @@ metadata:
   name: ingress-nginx-controller
   namespace: ingress-nginx
   labels:
-    helm.sh/chart: ingress-nginx-4.14.3
+    helm.sh/chart: ingress-nginx-4.15.1
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/version: "1.14.3"
+    app.kubernetes.io/version: "1.15.1"
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: controller

--- a/katalog/nginx/bases/configs/Role-ingress-nginx.yml
+++ b/katalog/nginx/bases/configs/Role-ingress-nginx.yml
@@ -8,10 +8,10 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   labels:
-    helm.sh/chart: ingress-nginx-4.14.3
+    helm.sh/chart: ingress-nginx-4.15.1
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/version: "1.14.3"
+    app.kubernetes.io/version: "1.15.1"
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: controller

--- a/katalog/nginx/bases/configs/RoleBinding-ingress-nginx.yml
+++ b/katalog/nginx/bases/configs/RoleBinding-ingress-nginx.yml
@@ -8,10 +8,10 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   labels:
-    helm.sh/chart: ingress-nginx-4.14.3
+    helm.sh/chart: ingress-nginx-4.15.1
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/version: "1.14.3"
+    app.kubernetes.io/version: "1.15.1"
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: controller

--- a/katalog/nginx/bases/configs/Service-ingress-nginx-controller-metrics.yml
+++ b/katalog/nginx/bases/configs/Service-ingress-nginx-controller-metrics.yml
@@ -8,10 +8,10 @@ apiVersion: v1
 kind: Service
 metadata:
   labels:
-    helm.sh/chart: ingress-nginx-4.14.3
+    helm.sh/chart: ingress-nginx-4.15.1
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/version: "1.14.3"
+    app.kubernetes.io/version: "1.15.1"
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: controller

--- a/katalog/nginx/bases/configs/ServiceAccount-ingress-nginx.yml
+++ b/katalog/nginx/bases/configs/ServiceAccount-ingress-nginx.yml
@@ -8,10 +8,10 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   labels:
-    helm.sh/chart: ingress-nginx-4.14.3
+    helm.sh/chart: ingress-nginx-4.15.1
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/version: "1.14.3"
+    app.kubernetes.io/version: "1.15.1"
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: controller

--- a/katalog/nginx/bases/configs/ServiceMonitor-ingress-nginx-controller.yml
+++ b/katalog/nginx/bases/configs/ServiceMonitor-ingress-nginx-controller.yml
@@ -10,10 +10,10 @@ metadata:
   name: ingress-nginx-controller
   namespace: ingress-nginx
   labels:
-    helm.sh/chart: ingress-nginx-4.14.3
+    helm.sh/chart: ingress-nginx-4.15.1
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/version: "1.14.3"
+    app.kubernetes.io/version: "1.15.1"
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: controller

--- a/katalog/nginx/bases/controller/ConfigMap-ingress-nginx-controller.yml
+++ b/katalog/nginx/bases/controller/ConfigMap-ingress-nginx-controller.yml
@@ -8,10 +8,10 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   labels:
-    helm.sh/chart: ingress-nginx-4.14.3
+    helm.sh/chart: ingress-nginx-4.15.1
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/version: "1.14.3"
+    app.kubernetes.io/version: "1.15.1"
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: controller

--- a/katalog/nginx/bases/controller/DaemonSet-ingress-nginx-controller.yml
+++ b/katalog/nginx/bases/controller/DaemonSet-ingress-nginx-controller.yml
@@ -8,10 +8,10 @@ apiVersion: apps/v1
 kind: DaemonSet
 metadata:
   labels:
-    helm.sh/chart: ingress-nginx-4.14.3
+    helm.sh/chart: ingress-nginx-4.15.1
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/version: "1.14.3"
+    app.kubernetes.io/version: "1.15.1"
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: controller
@@ -33,10 +33,10 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: ingress-nginx-4.14.3
+        helm.sh/chart: ingress-nginx-4.15.1
         app.kubernetes.io/name: ingress-nginx
         app.kubernetes.io/instance: ingress-nginx
-        app.kubernetes.io/version: "1.14.3"
+        app.kubernetes.io/version: "1.15.1"
         app.kubernetes.io/part-of: ingress-nginx
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/component: controller
@@ -46,7 +46,7 @@ spec:
         fsGroup: 101
       containers:
         - name: controller
-          image: registry.sighup.io/fury/ingress-nginx/controller:v1.14.3
+          image: registry.sighup.io/fury/ingress-nginx/controller:v1.15.1
           imagePullPolicy: Always
           lifecycle:
             preStop:

--- a/katalog/nginx/bases/controller/IngressClass-nginx.yml
+++ b/katalog/nginx/bases/controller/IngressClass-nginx.yml
@@ -8,10 +8,10 @@ apiVersion: networking.k8s.io/v1
 kind: IngressClass
 metadata:
   labels:
-    helm.sh/chart: ingress-nginx-4.14.3
+    helm.sh/chart: ingress-nginx-4.15.1
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/version: "1.14.3"
+    app.kubernetes.io/version: "1.15.1"
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: controller

--- a/katalog/nginx/bases/controller/Service-ingress-nginx-controller-admission.yml
+++ b/katalog/nginx/bases/controller/Service-ingress-nginx-controller-admission.yml
@@ -8,10 +8,10 @@ apiVersion: v1
 kind: Service
 metadata:
   labels:
-    helm.sh/chart: ingress-nginx-4.14.3
+    helm.sh/chart: ingress-nginx-4.15.1
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/version: "1.14.3"
+    app.kubernetes.io/version: "1.15.1"
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: controller

--- a/katalog/nginx/bases/controller/Service-ingress-nginx-controller.yml
+++ b/katalog/nginx/bases/controller/Service-ingress-nginx-controller.yml
@@ -9,10 +9,10 @@ kind: Service
 metadata:
   annotations:
   labels:
-    helm.sh/chart: ingress-nginx-4.14.3
+    helm.sh/chart: ingress-nginx-4.15.1
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/version: "1.14.3"
+    app.kubernetes.io/version: "1.15.1"
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: controller

--- a/katalog/nginx/bases/controller/ValidatingWebhookConfiguration-ingress-nginx-admission.yml
+++ b/katalog/nginx/bases/controller/ValidatingWebhookConfiguration-ingress-nginx-admission.yml
@@ -13,10 +13,10 @@ metadata:
     certmanager.k8s.io/inject-ca-from: "ingress-nginx/ingress-nginx-admission"
     cert-manager.io/inject-ca-from: "ingress-nginx/ingress-nginx-admission"
   labels:
-    helm.sh/chart: ingress-nginx-4.14.3
+    helm.sh/chart: ingress-nginx-4.15.1
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/instance: ingress-nginx
-    app.kubernetes.io/version: "1.14.3"
+    app.kubernetes.io/version: "1.15.1"
     app.kubernetes.io/part-of: ingress-nginx
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: admission-webhook

--- a/katalog/nginx/bases/controller/kustomization.yaml
+++ b/katalog/nginx/bases/controller/kustomization.yaml
@@ -16,7 +16,7 @@ labels:
 images:
   - name: k8s.gcr.io/ingress-nginx/controller
     newName: registry.sighup.io/fury/ingress-nginx/controller
-    newTag: v1.14.3
+    newTag: v1.15.1
 
 resources:
   - Certificate-ingress-nginx-admission.yml

--- a/katalog/nginx/upgrade.sh
+++ b/katalog/nginx/upgrade.sh
@@ -7,7 +7,7 @@
 kustomize build . > current-release.yaml
 
 # Remember to change this version accordingly
-VERSION=4.14.3
+VERSION=4.15.1
 
 helm template ingress-nginx ingress-nginx \
   --repo https://kubernetes.github.io/ingress-nginx \


### PR DESCRIPTION
### Summary 💡

Security fix: upgrade `nginx` ingress controller to `v1.15.1` (CVSS 8.8 - annotation injection leading to RCE and secret disclosure). Add e2e tests for Kubernetes 1.35.

### Description 📝

- Upgraded `nginx` from `v1.14.3` to `v1.15.1` to address a security vulnerability where a combination of Ingress annotations can inject configuration into nginx, leading to arbitrary code execution and disclosure of Secrets accessible to the controller.
- Added Drone e2e pipeline for Kubernetes 1.35.0 (kind v0.31.0).

### Breaking Changes 💔

None.

### Tests performed 🧪

- [x] e2e tests pass [ci.sighup.io/sighupio/module-ingress/1512](https://ci.sighup.io/sighupio/module-ingress/1512/)

### Future work 🔧

- A separate PR will follow for the module release.
