### PR TITLE
feat: switch nginx-ingress controller to Chainguard-built image

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -62,7 +62,7 @@ steps:
       - render
     commands:
       # we use --ignore-deprecations because we don't want the CI to fail when the API has not been removed yet.
-      - /pluto detect $${KUBERNETES_MANIFESTS} --ignore-deprecations --target-versions=k8s=v1.34.0
+      - /pluto detect $${KUBERNETES_MANIFESTS} --ignore-deprecations --target-versions=k8s=v1.35.0
     environment:
       KUBERNETES_MANIFESTS: cert-manager.yml
 
@@ -163,7 +163,7 @@ steps:
         path: /mise-data
     commands:
       - |
-        mise use bats@1.1.0 kubectl@$${KUBECTL_VERSION} kustomize@5.6.0
+        mise use bats@1.11.0 kubectl@$${KUBECTL_VERSION} kustomize@5.6.0
         eval "$(mise activate bash --shims)"
       - . ./env-$${CLUSTER_NAME}.env
       - until kubectl get serviceaccount default > /dev/null 2>&1; do echo "waiting for control-plane" && sleep 1; done
@@ -270,7 +270,7 @@ steps:
         path: /mise-data
     commands:
       - |
-        mise use bats@1.1.0 kubectl@$${KUBECTL_VERSION} kustomize@5.6.0
+        mise use bats@1.11.0 kubectl@$${KUBECTL_VERSION} kustomize@5.6.0
         eval "$(mise activate bash --shims)"
       - . ./env-$${CLUSTER_NAME}.env
       - until kubectl get serviceaccount default > /dev/null 2>&1; do echo "waiting for control-plane" && sleep 1; done
@@ -377,7 +377,7 @@ steps:
         path: /mise-data
     commands:
       - |
-        mise use bats@1.1.0 kubectl@$${KUBECTL_VERSION} kustomize@5.6.0
+        mise use bats@1.11.0 kubectl@$${KUBECTL_VERSION} kustomize@5.6.0
         eval "$(mise activate bash --shims)"
       - . ./env-$${CLUSTER_NAME}.env
       - until kubectl get serviceaccount default > /dev/null 2>&1; do echo "waiting for control-plane" && sleep 1; done
@@ -484,7 +484,7 @@ steps:
         path: /mise-data
     commands:
       - |
-        mise use bats@1.1.0 kubectl@$${KUBECTL_VERSION} kustomize@5.6.0
+        mise use bats@1.11.0 kubectl@$${KUBECTL_VERSION} kustomize@5.6.0
         eval "$(mise activate bash --shims)"
       - . ./env-$${CLUSTER_NAME}.env
       - until kubectl get serviceaccount default > /dev/null 2>&1; do echo "waiting for control-plane" && sleep 1; done
@@ -556,7 +556,7 @@ steps:
       MISE_DATA_DIR: /mise-data
       MISE_OVERRIDE_CONFIG_FILENAMES: "mise.ci.toml"
       KIND_VERSION: "0.31.0"
-      KUBECTL_VERSION: "1.35.0"
+      KUBECTL_VERSION: "1.35.5"
       CLUSTER_NAME: ${DRONE_REPO_NAME}-${DRONE_BUILD_NUMBER}-1.35.0
       GITHUB_TOKEN:
         from_secret: github_token
@@ -581,7 +581,7 @@ steps:
     environment:
       MISE_DATA_DIR: /mise-data
       MISE_OVERRIDE_CONFIG_FILENAMES: "mise.ci.toml"
-      KUBECTL_VERSION: "1.35.0"
+      KUBECTL_VERSION: "1.35.5"
       KUBECONFIG: ./kubeconfig-${DRONE_REPO_NAME}-${DRONE_BUILD_NUMBER}-1.35.0
       CLUSTER_NAME: ${DRONE_REPO_NAME}-${DRONE_BUILD_NUMBER}-1.35.0
       GITHUB_TOKEN:
@@ -591,7 +591,7 @@ steps:
         path: /mise-data
     commands:
       - |
-        mise use bats@1.1.0 kubectl@$${KUBECTL_VERSION} kustomize@5.6.0
+        mise use bats@1.11.0 kubectl@$${KUBECTL_VERSION} kustomize@5.6.0
         eval "$(mise activate bash --shims)"
       - . ./env-$${CLUSTER_NAME}.env
       - until kubectl get serviceaccount default > /dev/null 2>&1; do echo "waiting for control-plane" && sleep 1; done
@@ -606,7 +606,7 @@ steps:
       MISE_DATA_DIR: /mise-data
       MISE_OVERRIDE_CONFIG_FILENAMES: "mise.ci.toml"
       KIND_VERSION: "0.31.0"
-      KUBECTL_VERSION: "1.35.0"
+      KUBECTL_VERSION: "1.35.5"
       CLUSTER_NAME: ${DRONE_REPO_NAME}-${DRONE_BUILD_NUMBER}-1.35.0
       GITHUB_TOKEN:
         from_secret: github_token

--- a/docs/releases/unreleased.md
+++ b/docs/releases/unreleased.md
@@ -1,0 +1,32 @@
+# Ingress Module Release (Unreleased)
+
+Welcome to the latest release of `Ingress` module of [`SIGHUP Distribution`](https://github.com/sighupio/fury-distribution) maintained by team SIGHUP.
+
+This release switches the `nginx-ingress` controller image to a custom build of the Chainguard fork, produced in-house in [`container-image-sync`](https://github.com/sighupio/container-image-sync). The published tag now carries a `-chainguard` suffix (`v1.15.5-chainguard`).
+
+This release also validates the module against **Kubernetes 1.35.x** (added to the e2e test matrix).
+
+## Component Images 🚢
+
+| Component          | Supported Version                                                                                       | Previous Version |
+| ------------------ | ------------------------------------------------------------------------------------------------------- | :--------------: |
+| `aws-cert-manager` | N.A.                                                                                                    |   `No update`    |
+| `aws-external-dns` | N.A.                                                                                                    |   `No update`    |
+| `cert-manager`     | [`v1.19.2`](https://cert-manager.io/docs/releases/release-notes/release-notes-1.19/)                    |   `No update`    |
+| `dual-nginx`       | [`v1.15.5-chainguard`](https://github.com/chainguard-forks/ingress-nginx/releases/tag/controller-v1.15.5) |    `v1.14.3`     |
+| `external-dns`     | [`v0.20.0`](https://github.com/kubernetes-sigs/external-dns/releases/tag/v0.20.0)                       |   `No update`    |
+| `forecastle`       | [`v1.0.159`](https://github.com/stakater/Forecastle/releases/tag/v1.0.159)                              |   `No update`    |
+| `haproxy`          | [`v3.2.4`](https://github.com/haproxytech/kubernetes-ingress/releases/tag/v3.2.4)                       |   `No update`    |
+| `nginx`            | [`v1.15.5-chainguard`](https://github.com/chainguard-forks/ingress-nginx/releases/tag/controller-v1.15.5) |    `v1.15.1`     |
+
+> Please refer the individual release notes to get a more detailed information on each release.
+
+## Update Guide 🦮
+
+### Process
+
+To upgrade this core module from `v5.0.1` to `v5.1.0`, you need to download this new version, and apply the instructions below.
+
+```bash
+kustomize build <your-project-path> | kubectl apply -f -
+```

--- a/katalog/dual-nginx/README.md
+++ b/katalog/dual-nginx/README.md
@@ -12,8 +12,9 @@ Ingress NGINX is an Ingress Controller for [NGINX][nginx-page] webserver and rev
 
 ## Image repository and tag
 
-- Ingress NGINX image: `k8s.gcr.io/ingress-nginx/controller:v1.15.1`
-- Ingress NGINX repo: [https://github.com/kubernetes/ingress-nginx](https://github.com/kubernetes/ingress-nginx)
+- Ingress NGINX image: `registry.sighup.io/fury/ingress-nginx/controller:v1.15.5-chainguard` (built in-house from the Chainguard-maintained fork)
+- Ingress NGINX upstream repo (archived): [https://github.com/kubernetes/ingress-nginx](https://github.com/kubernetes/ingress-nginx)
+- Ingress NGINX fork repo (maintained): [https://github.com/chainguard-forks/ingress-nginx](https://github.com/chainguard-forks/ingress-nginx)
 
 ## Configuration
 

--- a/katalog/nginx/MAINTENANCE.md
+++ b/katalog/nginx/MAINTENANCE.md
@@ -1,8 +1,16 @@
 # Ingress NGINX controller package maintenance guide
 
-**Current Version**: v1.15.1 (Helm Chart 4.15.1)
-**Previous Version**: v1.14.1 (Helm Chart 4.14.1)
-**Last Updated**: April 2026
+**Current Version**: v1.15.5-chainguard (Helm Chart 4.15.5)
+**Previous Version**: v1.15.1 (Helm Chart 4.15.1)
+**Last Updated**: May 2026
+
+> ℹ️ **Image source**: starting from `v1.15.5-chainguard`, the controller image is
+> built in-house from the Chainguard-maintained fork ([`chainguard-forks/ingress-nginx`](https://github.com/chainguard-forks/ingress-nginx))
+> through the [`container-image-sync`](https://github.com/sighupio/container-image-sync) repository
+> (see `modules/chainguard-forks/` there). The upstream `kubernetes/ingress-nginx`
+> project is archived; the upgrade procedure below still uses the upstream Helm
+> chart as a template for the Kubernetes manifests but the controller image tag
+> tracked here follows fork releases (`controller-vX.Y.Z` tags on the fork).
 
 To update Ingress NGINX controller, follow the next steps (or update and use the [upgrade.sh](./upgrade.sh) script to automate it):
 
@@ -20,12 +28,12 @@ kustomize build . > current-release.yaml
 
 ## Upgrade files
 
-1. Go to the [ingress NGINX controller repository](https://github.com/kubernetes/ingress-nginx/) and check the latest release.
+1. Go to the [ingress NGINX controller repository (Chainguard fork)](https://github.com/chainguard-forks/ingress-nginx/) and check the latest release. The fork uses the same `controller-vX.Y.Z` tag scheme as the (archived) [upstream](https://github.com/kubernetes/ingress-nginx/).
 
 > 💡 TIP
 > Controller releases are published as `controller-vX.Y.Z` tags and chart releases with `helm-chart-X.Y.Z`.
 >
-> You can also find a compatibility table in the project's [main README file](https://github.com/kubernetes/ingress-nginx?tab=readme-ov-file#supported-versions-table).
+> The upstream `kubernetes/ingress-nginx` compatibility table ([main README](https://github.com/kubernetes/ingress-nginx?tab=readme-ov-file#supported-versions-table)) is no longer maintained since the upstream archive; the fork may publish its own — verify at each bump.
 
 1. Helm template the content using the following command:
 

--- a/katalog/nginx/MAINTENANCE.values.yml
+++ b/katalog/nginx/MAINTENANCE.values.yml
@@ -10,7 +10,7 @@ controller:
   image:
     registry: registry.sighup.io
     image: fury/ingress-nginx/controller
-    tag: "v1.15.1"
+    tag: "v1.15.5-chainguard"
     pullPolicy: Always
     digest: ""
   containerPort:

--- a/katalog/nginx/README.md
+++ b/katalog/nginx/README.md
@@ -12,8 +12,9 @@ Ingress NGINX is an Ingress Controller for [NGINX][nginx-page] web server and re
 
 ## Image repository and tag
 
-- Ingress NGINX image: `k8s.gcr.io/ingress-nginx/controller:v1.15.1`
-- Ingress NGINX repo: [https://github.com/kubernetes/ingress-nginx](https://github.com/kubernetes/ingress-nginx)
+- Ingress NGINX image: `registry.sighup.io/fury/ingress-nginx/controller:v1.15.5-chainguard` (built in-house from the Chainguard-maintained fork)
+- Ingress NGINX upstream repo (archived): [https://github.com/kubernetes/ingress-nginx](https://github.com/kubernetes/ingress-nginx)
+- Ingress NGINX fork repo (maintained): [https://github.com/chainguard-forks/ingress-nginx](https://github.com/chainguard-forks/ingress-nginx)
 
 ## Configuration
 

--- a/katalog/nginx/bases/controller/DaemonSet-ingress-nginx-controller.yml
+++ b/katalog/nginx/bases/controller/DaemonSet-ingress-nginx-controller.yml
@@ -46,7 +46,7 @@ spec:
         fsGroup: 101
       containers:
         - name: controller
-          image: registry.sighup.io/fury/ingress-nginx/controller:v1.15.1
+          image: registry.sighup.io/fury/ingress-nginx/controller:v1.15.5-chainguard
           imagePullPolicy: Always
           lifecycle:
             preStop:

--- a/katalog/nginx/bases/controller/kustomization.yaml
+++ b/katalog/nginx/bases/controller/kustomization.yaml
@@ -16,7 +16,7 @@ labels:
 images:
   - name: k8s.gcr.io/ingress-nginx/controller
     newName: registry.sighup.io/fury/ingress-nginx/controller
-    newTag: v1.15.1
+    newTag: v1.15.5-chainguard
 
 resources:
   - Certificate-ingress-nginx-admission.yml

--- a/mise.toml
+++ b/mise.toml
@@ -3,8 +3,8 @@
 # license that can be found in the LICENSE file.
 
 [tools]
-kind = "0.29.0"    
-kubectl = "1.33.4" 
+kind = "0.31.0"
+kubectl = "1.35.5"
 kustomize = "5.6.0"
 helm = "3.15.0"    
 yq = "4.43.1"      
@@ -64,7 +64,7 @@ echo "✅ E2E tests completed successfully!"
 '''
 
 [tasks.e2e-create]
-description = "Create Kind cluster for E2E tests (K8s 1.33)"
+description = "Create Kind cluster for E2E tests (K8s 1.35)"
 run = '''
 #!/bin/bash
 set -e
@@ -73,7 +73,7 @@ echo "📦 Creating E2E Test Environment"
 echo "================================="
 
 # Configuration
-KUBE_VERSION="1.33.0"
+KUBE_VERSION="1.35.0"
 export DRONE_BUILD_NUMBER="${DRONE_BUILD_NUMBER:-9999}"
 export DRONE_REPO_NAME="${DRONE_REPO_NAME:-module-ingress}"
 CLUSTER_NAME="${DRONE_REPO_NAME}-${DRONE_BUILD_NUMBER}-${KUBE_VERSION}"
@@ -125,7 +125,7 @@ echo "🧪 Running E2E Tests"
 echo "===================="
 
 # Configuration
-KUBE_VERSION="1.33.0"
+KUBE_VERSION="1.35.0"
 export DRONE_BUILD_NUMBER="${DRONE_BUILD_NUMBER:-9999}"
 export DRONE_REPO_NAME="${DRONE_REPO_NAME:-module-ingress}"
 CLUSTER_NAME="${DRONE_REPO_NAME}-${DRONE_BUILD_NUMBER}-${KUBE_VERSION}"
@@ -159,7 +159,7 @@ echo "✅ Tests completed!"
 description = "Cleanup the E2E test cluster and generated files"
 run = '''
 #!/bin/bash
-KUBE_VERSION="1.33.0"
+KUBE_VERSION="1.35.0"
 DRONE_BUILD_NUMBER="${DRONE_BUILD_NUMBER:-9999}"
 DRONE_REPO_NAME="${DRONE_REPO_NAME:-module-ingress}"
 CLUSTER_NAME="${DRONE_REPO_NAME}-${DRONE_BUILD_NUMBER}-${KUBE_VERSION}"


### PR DESCRIPTION
### Summary 💡

Switch the `nginx-ingress` controller image from the upstream mirror (`v1.15.1`, now archived) to an in-house build of the Chainguard-maintained fork (`v1.15.5-chainguard`), produced in `container-image-sync`. Also validates the module against Kubernetes 1.35.

Closes:

Relates:
- sighupio/container-image-sync (builds `ingress-nginx/{nginx,controller}:*-chainguard` under `modules/chainguard-forks/`)

### Description 📝

- Controller image bumped to `registry.sighup.io/fury/ingress-nginx/controller:v1.15.5-chainguard` in `katalog/nginx/bases/controller` (kustomization + DaemonSet) and `MAINTENANCE.values.yml`.
- Docs realigned to the fork source: `katalog/nginx/README.md`, `katalog/dual-nginx/README.md`, `katalog/nginx/MAINTENANCE.md`.
- K8s 1.35 tooling alignment: pluto target → `v1.35.0`, bats → `1.11.0`, kubectl client → `1.35.5` (1.35 e2e block), local-dev `mise.toml` defaults → 1.35.
- Release notes in `docs/releases/unreleased.md`.

### Breaking Changes 💔

- None

### Tests performed 🧪

- [x] Local e2e suite (`mise run e2e`) on Kind **K8s v1.35.0** — **47/47 passed** (nginx + haproxy routing & isolation, cert-manager, dual-nginx running the new `-chainguard` image)
- [x] CI e2e tests

### Future work 🔧

- Add the `v5.1.0` row to `COMPATIBILITY_MATRIX.md` at release time.