### PR TITLE
feat: bump HAProxy ingress controller to v3.2.8

### DIFF
--- a/docs/releases/unreleased.md
+++ b/docs/releases/unreleased.md
@@ -4,7 +4,24 @@ Welcome to the latest release of `Ingress` module of [`SIGHUP Distribution`](htt
 
 This release switches the `nginx-ingress` controller image to a custom build of the Chainguard fork, produced in-house in [`container-image-sync`](https://github.com/sighupio/container-image-sync). The published tag now carries a `-chainguard` suffix (`v1.15.5-chainguard`).
 
-This release also validates the module against **Kubernetes 1.35.x** (added to the e2e test matrix).
+This release also validates the module against **Kubernetes 1.35.x** (added to the e2e test matrix) and bumps the HAProxy ingress controller to `v3.2.8`.
+
+## Breaking Changes 💔
+
+The HAProxy chart bump (`v3.2.4` → `v3.2.8`) restructured the CRD-installer Job:
+
+- It was **renamed**: `haproxy-ingress-crdjob-1` → `haproxy-ingress-crdjob`
+  (in dual mode `haproxy-ingress-internal-crdjob-1` → `haproxy-ingress-internal-crdjob`).
+- The CRD-installer now ships **dedicated RBAC** (`ServiceAccount`, `ClusterRole`,
+  `ClusterRoleBinding` named `*-crdjob`), instead of reusing the controller's main
+  ServiceAccount.
+
+If you patch or reference these resources by name (e.g. to add `nodeSelector`/
+`tolerations`, or in GitOps/RBAC tooling), update the references to the new names.
+
+In **dual** mode only the `internal` CRD-installer runs — the `external` crdjob and its
+RBAC are removed, since CRDs are cluster-scoped and installing them once is enough.
+Patches in dual mode must target `haproxy-ingress-internal-crdjob`.
 
 ## Component Images 🚢
 
@@ -16,7 +33,7 @@ This release also validates the module against **Kubernetes 1.35.x** (added to t
 | `dual-nginx`       | [`v1.15.5-chainguard`](https://github.com/chainguard-forks/ingress-nginx/releases/tag/controller-v1.15.5) |    `v1.14.3`     |
 | `external-dns`     | [`v0.20.0`](https://github.com/kubernetes-sigs/external-dns/releases/tag/v0.20.0)                       |   `No update`    |
 | `forecastle`       | [`v1.0.159`](https://github.com/stakater/Forecastle/releases/tag/v1.0.159)                              |   `No update`    |
-| `haproxy`          | [`v3.2.4`](https://github.com/haproxytech/kubernetes-ingress/releases/tag/v3.2.4)                       |   `No update`    |
+| `haproxy`          | [`v3.2.8`](https://github.com/haproxytech/kubernetes-ingress/releases/tag/v3.2.8)                       |    `v3.2.4`      |
 | `nginx`            | [`v1.15.5-chainguard`](https://github.com/chainguard-forks/ingress-nginx/releases/tag/controller-v1.15.5) |    `v1.15.1`     |
 
 > Please refer the individual release notes to get a more detailed information on each release.

--- a/katalog/haproxy/MAINTENANCE.values.yaml
+++ b/katalog/haproxy/MAINTENANCE.values.yaml
@@ -22,7 +22,7 @@ controller:
     secret: "haproxy-ingress-default-cert"
   image:
     repository: registry.sighup.io/fury/haproxytech/kubernetes-ingress
-    tag: "3.2.4"
+    tag: "3.2.8"
     pullPolicy: Always
   containerPort:
     http: 8080
@@ -70,8 +70,10 @@ controller:
         interval: 10s
   podLabels:
     k8s-app: haproxy-ingress
-  extraArgs:
-    - --prometheus
+  prometheus:
+    enabled: true
+  pprof:
+    enabled: false
   resources:
     requests:
       cpu: 250m

--- a/katalog/haproxy/README.md
+++ b/katalog/haproxy/README.md
@@ -12,7 +12,7 @@
 
 ## Image repository and tag
 
-- HAProxy Ingress Controller image: `registry.sighup.io/fury/haproxytech/kubernetes-ingress:3.2.4`
+- HAProxy Ingress Controller image: `registry.sighup.io/fury/haproxytech/kubernetes-ingress:3.2.8`
 - HAProxy Ingress Controller repo: [https://github.com/haproxytech/kubernetes-ingress](https://github.com/haproxytech/kubernetes-ingress)
 
 ## Configuration

--- a/katalog/haproxy/dual/external/ClusterRole-haproxy-ingress-external-crdjob.yaml
+++ b/katalog/haproxy/dual/external/ClusterRole-haproxy-ingress-external-crdjob.yaml
@@ -1,0 +1,35 @@
+# Copyright (c) 2017-present SIGHUP s.r.l All rights reserved.
+# Use of this source code is governed by a BSD-style
+# license that can be found in the LICENSE file.
+
+---
+# Source: kubernetes-ingress/templates/controller-crdjob-rbac.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: haproxy-ingress-external-crdjob
+  labels:
+    app.kubernetes.io/name: haproxy-ingress-external-proxy
+    app.kubernetes.io/instance: haproxy-ingress
+    helm.sh/chart: kubernetes-ingress-1.51.1
+    app.kubernetes.io/version: "3.2.8"
+    app.kubernetes.io/managed-by: Helm
+  annotations:
+    helm.sh/hook: post-install,pre-upgrade
+    helm.sh/hook-weight: "-5"
+    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
+    argocd.argoproj.io/hook: Sync
+    argocd.argoproj.io/hook-delete-policy: HookSucceeded
+rules:
+  - apiGroups:
+      - "apiextensions.k8s.io"
+    resources:
+      - customresourcedefinitions
+    verbs:
+      - get
+      - list
+      - watch
+      - create
+      - update
+      - patch
+      - delete

--- a/katalog/haproxy/dual/external/ClusterRole-haproxy-ingress-external.yaml
+++ b/katalog/haproxy/dual/external/ClusterRole-haproxy-ingress-external.yaml
@@ -11,8 +11,8 @@ metadata:
   labels:
     app.kubernetes.io/name: kubernetes-ingress
     app.kubernetes.io/instance: haproxy-ingress
-    helm.sh/chart: kubernetes-ingress-1.47.4
-    app.kubernetes.io/version: "3.2.4"
+    helm.sh/chart: kubernetes-ingress-1.51.1
+    app.kubernetes.io/version: "3.2.8"
     app.kubernetes.io/managed-by: Helm
 rules:
   - apiGroups:
@@ -70,7 +70,7 @@ rules:
   - apiGroups:
       - core.haproxy.org
     resources:
-      - '*'
+      - "*"
     verbs:
       - get
       - list

--- a/katalog/haproxy/dual/external/ClusterRoleBinding-haproxy-ingress-external-crdjob.yaml
+++ b/katalog/haproxy/dual/external/ClusterRoleBinding-haproxy-ingress-external-crdjob.yaml
@@ -3,22 +3,28 @@
 # license that can be found in the LICENSE file.
 
 ---
-# Source: kubernetes-ingress/templates/clusterrolebinding.yaml
+# Source: kubernetes-ingress/templates/controller-crdjob-rbac.yaml
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: haproxy-ingress-internal
+  name: haproxy-ingress-external-crdjob
   labels:
-    app.kubernetes.io/name: kubernetes-ingress
+    app.kubernetes.io/name: haproxy-ingress-external-proxy
     app.kubernetes.io/instance: haproxy-ingress
     helm.sh/chart: kubernetes-ingress-1.51.1
     app.kubernetes.io/version: "3.2.8"
     app.kubernetes.io/managed-by: Helm
+  annotations:
+    helm.sh/hook: post-install,pre-upgrade
+    helm.sh/hook-weight: "-5"
+    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
+    argocd.argoproj.io/hook: Sync
+    argocd.argoproj.io/hook-delete-policy: HookSucceeded
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: haproxy-ingress-internal
+  name: haproxy-ingress-external-crdjob
 subjects:
   - kind: ServiceAccount
-    name: haproxy-ingress
+    name: haproxy-ingress-external-crdjob
     namespace: ingress-haproxy

--- a/katalog/haproxy/dual/external/ClusterRoleBinding-haproxy-ingress-external.yaml
+++ b/katalog/haproxy/dual/external/ClusterRoleBinding-haproxy-ingress-external.yaml
@@ -11,8 +11,8 @@ metadata:
   labels:
     app.kubernetes.io/name: kubernetes-ingress
     app.kubernetes.io/instance: haproxy-ingress
-    helm.sh/chart: kubernetes-ingress-1.47.4
-    app.kubernetes.io/version: "3.2.4"
+    helm.sh/chart: kubernetes-ingress-1.51.1
+    app.kubernetes.io/version: "3.2.8"
     app.kubernetes.io/managed-by: Helm
 roleRef:
   apiGroup: rbac.authorization.k8s.io

--- a/katalog/haproxy/dual/external/ConfigMap-haproxy-ingress-external.yaml
+++ b/katalog/haproxy/dual/external/ConfigMap-haproxy-ingress-external.yaml
@@ -12,8 +12,8 @@ metadata:
   labels:
     app.kubernetes.io/name: kubernetes-ingress
     app.kubernetes.io/instance: haproxy-ingress
-    helm.sh/chart: kubernetes-ingress-1.47.4
-    app.kubernetes.io/version: "3.2.4"
+    helm.sh/chart: kubernetes-ingress-1.51.1
+    app.kubernetes.io/version: "3.2.8"
     app.kubernetes.io/managed-by: Helm
 data:
   log-format: '%ci - - [%Tl] "%[capture.req.hdr(0)]" "%HM %HPO%HQ %HV" %ST %B "%[capture.req.hdr(1)]" "%[capture.req.hdr(2)]" %U %TR [%b] [] %si:%sp %B %Tr %ST %ID'

--- a/katalog/haproxy/dual/external/DaemonSet-haproxy-ingress-external.yaml
+++ b/katalog/haproxy/dual/external/DaemonSet-haproxy-ingress-external.yaml
@@ -12,8 +12,8 @@ metadata:
   labels:
     app.kubernetes.io/name: kubernetes-ingress
     app.kubernetes.io/instance: haproxy-ingress
-    helm.sh/chart: kubernetes-ingress-1.47.4
-    app.kubernetes.io/version: "3.2.4"
+    helm.sh/chart: kubernetes-ingress-1.51.1
+    app.kubernetes.io/version: "3.2.8"
     app.kubernetes.io/managed-by: Helm
 spec:
   minReadySeconds: 0
@@ -42,7 +42,7 @@ spec:
         runAsGroup: 1000
       containers:
         - name: kubernetes-ingress-controller
-          image: "registry.sighup.io/fury/haproxytech/kubernetes-ingress:3.2.4"
+          image: "registry.sighup.io/fury/haproxytech/kubernetes-ingress:3.2.8"
           imagePullPolicy: Always
           args:
             - --default-ssl-certificate=ingress-haproxy/haproxy-ingress-default-cert
@@ -54,9 +54,6 @@ spec:
             - --log=info
             - --prometheus
           securityContext:
-            runAsNonRoot: true
-            runAsUser: 1000
-            runAsGroup: 1000
             allowPrivilegeEscalation: false
             capabilities:
               drop:

--- a/katalog/haproxy/dual/external/IngressClass-haproxy-external.yaml
+++ b/katalog/haproxy/dual/external/IngressClass-haproxy-external.yaml
@@ -11,8 +11,8 @@ metadata:
   labels:
     app.kubernetes.io/name: kubernetes-ingress
     app.kubernetes.io/instance: haproxy-ingress
-    helm.sh/chart: kubernetes-ingress-1.47.4
-    app.kubernetes.io/version: "3.2.4"
+    helm.sh/chart: kubernetes-ingress-1.51.1
+    app.kubernetes.io/version: "3.2.8"
     app.kubernetes.io/managed-by: Helm
 spec:
   controller: haproxy.org/ingress-controller/haproxy-external

--- a/katalog/haproxy/dual/external/Job-haproxy-ingress-external-crdjob.yaml
+++ b/katalog/haproxy/dual/external/Job-haproxy-ingress-external-crdjob.yaml
@@ -7,34 +7,39 @@
 apiVersion: batch/v1
 kind: Job
 metadata:
-  name: haproxy-ingress-internal-crdjob-1
+  name: haproxy-ingress-external-crdjob
   namespace: ingress-haproxy
   labels:
-    app.kubernetes.io/name: haproxy-ingress-internal-proxy
+    app.kubernetes.io/name: haproxy-ingress-external-proxy
     app.kubernetes.io/instance: haproxy-ingress
-    helm.sh/chart: kubernetes-ingress-1.47.4
-    app.kubernetes.io/version: "3.2.4"
+    helm.sh/chart: kubernetes-ingress-1.51.1
+    app.kubernetes.io/version: "3.2.8"
     app.kubernetes.io/managed-by: Helm
+  annotations:
+    argocd.argoproj.io/hook: Sync
+    argocd.argoproj.io/hook-delete-policy: HookSucceeded
+    helm.sh/hook: post-install,pre-upgrade
+    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
 spec:
   ttlSecondsAfterFinished: 600
   backoffLimit: 0
   template:
     metadata:
       labels:
-        app.kubernetes.io/name: haproxy-ingress-internal-proxy
+        app.kubernetes.io/name: haproxy-ingress-external-proxy
         app.kubernetes.io/instance: haproxy-ingress
         k8s-app: haproxy-ingress
-        type: internal
+        type: external
     spec:
       restartPolicy: Never
-      serviceAccountName: haproxy-ingress
+      serviceAccountName: haproxy-ingress-external-crdjob
       securityContext:
         runAsNonRoot: true
         runAsUser: 1000
         runAsGroup: 1000
       containers:
         - name: crd
-          image: "registry.sighup.io/fury/haproxytech/kubernetes-ingress:3.2.4"
+          image: "registry.sighup.io/fury/haproxytech/kubernetes-ingress:3.2.8"
           imagePullPolicy: Always
           command:
             - /haproxy-ingress-controller

--- a/katalog/haproxy/dual/external/Namespace-ingress-haproxy.yaml
+++ b/katalog/haproxy/dual/external/Namespace-ingress-haproxy.yaml
@@ -11,7 +11,6 @@ metadata:
   labels:
     app.kubernetes.io/name: kubernetes-ingress
     app.kubernetes.io/instance: haproxy-ingress
-    helm.sh/chart: kubernetes-ingress-1.47.4
-    app.kubernetes.io/version: "3.2.4"
+    helm.sh/chart: kubernetes-ingress-1.51.1
+    app.kubernetes.io/version: "3.2.8"
     app.kubernetes.io/managed-by: Helm
-

--- a/katalog/haproxy/dual/external/Service-haproxy-ingress-external-admin.yaml
+++ b/katalog/haproxy/dual/external/Service-haproxy-ingress-external-admin.yaml
@@ -11,8 +11,8 @@ metadata:
   labels:
     app.kubernetes.io/name: kubernetes-ingress
     app.kubernetes.io/instance: haproxy-ingress
-    helm.sh/chart: kubernetes-ingress-1.46.1
-    app.kubernetes.io/version: "3.1.14"
+    helm.sh/chart: kubernetes-ingress-1.51.1
+    app.kubernetes.io/version: "3.2.8"
     app.kubernetes.io/managed-by: Helm
     k8s-app: haproxy-ingress
     type: external

--- a/katalog/haproxy/dual/external/Service-haproxy-ingress-external-metrics.yaml
+++ b/katalog/haproxy/dual/external/Service-haproxy-ingress-external-metrics.yaml
@@ -12,10 +12,10 @@ metadata:
   labels:
     app.kubernetes.io/name: kubernetes-ingress
     app.kubernetes.io/instance: haproxy-ingress
-    helm.sh/chart: kubernetes-ingress-1.47.4
-    app.kubernetes.io/version: "3.2.4"
+    helm.sh/chart: kubernetes-ingress-1.51.1
+    app.kubernetes.io/version: "3.2.8"
     app.kubernetes.io/managed-by: Helm
-  annotations:
+    app.kubernetes.io/component: metrics
 spec:
   type: ClusterIP
   ports:

--- a/katalog/haproxy/dual/external/Service-haproxy-ingress-external.yaml
+++ b/katalog/haproxy/dual/external/Service-haproxy-ingress-external.yaml
@@ -12,12 +12,11 @@ metadata:
   labels:
     app.kubernetes.io/name: kubernetes-ingress
     app.kubernetes.io/instance: haproxy-ingress
-    helm.sh/chart: kubernetes-ingress-1.47.4
-    app.kubernetes.io/version: "3.2.4"
+    helm.sh/chart: kubernetes-ingress-1.51.1
+    app.kubernetes.io/version: "3.2.8"
     app.kubernetes.io/managed-by: Helm
     k8s-app: haproxy-ingress
     type: external
-  annotations:
 spec:
   type: NodePort
   externalTrafficPolicy: Local

--- a/katalog/haproxy/dual/external/ServiceAccount-haproxy-ingress-external-crdjob.yaml
+++ b/katalog/haproxy/dual/external/ServiceAccount-haproxy-ingress-external-crdjob.yaml
@@ -3,16 +3,21 @@
 # license that can be found in the LICENSE file.
 
 ---
-# Source: kubernetes-ingress/templates/controller-serviceaccount.yaml
+# Source: kubernetes-ingress/templates/controller-crdjob-rbac.yaml
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: haproxy-ingress
+  name: haproxy-ingress-external-crdjob
   namespace: ingress-haproxy
   labels:
-    app.kubernetes.io/name: kubernetes-ingress
+    app.kubernetes.io/name: haproxy-ingress-external-proxy
     app.kubernetes.io/instance: haproxy-ingress
     helm.sh/chart: kubernetes-ingress-1.51.1
     app.kubernetes.io/version: "3.2.8"
     app.kubernetes.io/managed-by: Helm
-automountServiceAccountToken: true
+  annotations:
+    helm.sh/hook: post-install,pre-upgrade
+    helm.sh/hook-weight: "-5"
+    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
+    argocd.argoproj.io/hook: Sync
+    argocd.argoproj.io/hook-delete-policy: HookSucceeded

--- a/katalog/haproxy/dual/external/ServiceAccount-haproxy-ingress.yaml
+++ b/katalog/haproxy/dual/external/ServiceAccount-haproxy-ingress.yaml
@@ -12,7 +12,7 @@ metadata:
   labels:
     app.kubernetes.io/name: kubernetes-ingress
     app.kubernetes.io/instance: haproxy-ingress
-    helm.sh/chart: kubernetes-ingress-1.47.4
-    app.kubernetes.io/version: "3.2.4"
+    helm.sh/chart: kubernetes-ingress-1.51.1
+    app.kubernetes.io/version: "3.2.8"
     app.kubernetes.io/managed-by: Helm
 automountServiceAccountToken: true

--- a/katalog/haproxy/dual/external/ServiceMonitor-haproxy-ingress-external.yaml
+++ b/katalog/haproxy/dual/external/ServiceMonitor-haproxy-ingress-external.yaml
@@ -12,8 +12,8 @@ metadata:
   labels:
     app.kubernetes.io/name: kubernetes-ingress
     app.kubernetes.io/instance: haproxy-ingress
-    helm.sh/chart: kubernetes-ingress-1.47.4
-    app.kubernetes.io/version: "3.2.4"
+    helm.sh/chart: kubernetes-ingress-1.51.1
+    app.kubernetes.io/version: "3.2.8"
     app.kubernetes.io/managed-by: Helm
     k8s-app: haproxy-ingress
 spec:
@@ -29,3 +29,4 @@ spec:
     matchLabels:
       app.kubernetes.io/name: kubernetes-ingress
       app.kubernetes.io/instance: haproxy-ingress
+      app.kubernetes.io/component: metrics

--- a/katalog/haproxy/dual/external/kustomization.yaml
+++ b/katalog/haproxy/dual/external/kustomization.yaml
@@ -17,7 +17,10 @@ resources:
   - Service-haproxy-ingress-external-metrics.yaml
   - ServiceMonitor-haproxy-ingress-external.yaml
   - IngressClass-haproxy-external.yaml
-  - Job-haproxy-ingress-external-crdjob-1.yaml
+  - ServiceAccount-haproxy-ingress-external-crdjob.yaml
+  - ClusterRole-haproxy-ingress-external-crdjob.yaml
+  - ClusterRoleBinding-haproxy-ingress-external-crdjob.yaml
+  - Job-haproxy-ingress-external-crdjob.yaml
 
 patches:
   - target:

--- a/katalog/haproxy/dual/internal/ClusterRole-haproxy-ingress-internal-crdjob.yaml
+++ b/katalog/haproxy/dual/internal/ClusterRole-haproxy-ingress-internal-crdjob.yaml
@@ -1,0 +1,35 @@
+# Copyright (c) 2017-present SIGHUP s.r.l All rights reserved.
+# Use of this source code is governed by a BSD-style
+# license that can be found in the LICENSE file.
+
+---
+# Source: kubernetes-ingress/templates/controller-crdjob-rbac.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: haproxy-ingress-internal-crdjob
+  labels:
+    app.kubernetes.io/name: haproxy-ingress-internal-proxy
+    app.kubernetes.io/instance: haproxy-ingress
+    helm.sh/chart: kubernetes-ingress-1.51.1
+    app.kubernetes.io/version: "3.2.8"
+    app.kubernetes.io/managed-by: Helm
+  annotations:
+    helm.sh/hook: post-install,pre-upgrade
+    helm.sh/hook-weight: "-5"
+    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
+    argocd.argoproj.io/hook: Sync
+    argocd.argoproj.io/hook-delete-policy: HookSucceeded
+rules:
+  - apiGroups:
+      - "apiextensions.k8s.io"
+    resources:
+      - customresourcedefinitions
+    verbs:
+      - get
+      - list
+      - watch
+      - create
+      - update
+      - patch
+      - delete

--- a/katalog/haproxy/dual/internal/ClusterRole-haproxy-ingress-internal.yaml
+++ b/katalog/haproxy/dual/internal/ClusterRole-haproxy-ingress-internal.yaml
@@ -11,8 +11,8 @@ metadata:
   labels:
     app.kubernetes.io/name: kubernetes-ingress
     app.kubernetes.io/instance: haproxy-ingress
-    helm.sh/chart: kubernetes-ingress-1.47.4
-    app.kubernetes.io/version: "3.2.4"
+    helm.sh/chart: kubernetes-ingress-1.51.1
+    app.kubernetes.io/version: "3.2.8"
     app.kubernetes.io/managed-by: Helm
 rules:
   - apiGroups:
@@ -70,7 +70,7 @@ rules:
   - apiGroups:
       - core.haproxy.org
     resources:
-      - '*'
+      - "*"
     verbs:
       - get
       - list

--- a/katalog/haproxy/dual/internal/ClusterRoleBinding-haproxy-ingress-internal-crdjob.yaml
+++ b/katalog/haproxy/dual/internal/ClusterRoleBinding-haproxy-ingress-internal-crdjob.yaml
@@ -3,22 +3,28 @@
 # license that can be found in the LICENSE file.
 
 ---
-# Source: kubernetes-ingress/templates/clusterrolebinding.yaml
+# Source: kubernetes-ingress/templates/controller-crdjob-rbac.yaml
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: haproxy-ingress-internal
+  name: haproxy-ingress-internal-crdjob
   labels:
-    app.kubernetes.io/name: kubernetes-ingress
+    app.kubernetes.io/name: haproxy-ingress-internal-proxy
     app.kubernetes.io/instance: haproxy-ingress
     helm.sh/chart: kubernetes-ingress-1.51.1
     app.kubernetes.io/version: "3.2.8"
     app.kubernetes.io/managed-by: Helm
+  annotations:
+    helm.sh/hook: post-install,pre-upgrade
+    helm.sh/hook-weight: "-5"
+    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
+    argocd.argoproj.io/hook: Sync
+    argocd.argoproj.io/hook-delete-policy: HookSucceeded
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: haproxy-ingress-internal
+  name: haproxy-ingress-internal-crdjob
 subjects:
   - kind: ServiceAccount
-    name: haproxy-ingress
+    name: haproxy-ingress-internal-crdjob
     namespace: ingress-haproxy

--- a/katalog/haproxy/dual/internal/ConfigMap-haproxy-ingress-internal.yaml
+++ b/katalog/haproxy/dual/internal/ConfigMap-haproxy-ingress-internal.yaml
@@ -12,8 +12,8 @@ metadata:
   labels:
     app.kubernetes.io/name: kubernetes-ingress
     app.kubernetes.io/instance: haproxy-ingress
-    helm.sh/chart: kubernetes-ingress-1.47.4
-    app.kubernetes.io/version: "3.2.4"
+    helm.sh/chart: kubernetes-ingress-1.51.1
+    app.kubernetes.io/version: "3.2.8"
     app.kubernetes.io/managed-by: Helm
 data:
   log-format: '%ci - - [%Tl] "%[capture.req.hdr(0)]" "%HM %HPO%HQ %HV" %ST %B "%[capture.req.hdr(1)]" "%[capture.req.hdr(2)]" %U %TR [%b] [] %si:%sp %B %Tr %ST %ID'

--- a/katalog/haproxy/dual/internal/DaemonSet-haproxy-ingress-internal.yaml
+++ b/katalog/haproxy/dual/internal/DaemonSet-haproxy-ingress-internal.yaml
@@ -12,8 +12,8 @@ metadata:
   labels:
     app.kubernetes.io/name: kubernetes-ingress
     app.kubernetes.io/instance: haproxy-ingress
-    helm.sh/chart: kubernetes-ingress-1.47.4
-    app.kubernetes.io/version: "3.2.4"
+    helm.sh/chart: kubernetes-ingress-1.51.1
+    app.kubernetes.io/version: "3.2.8"
     app.kubernetes.io/managed-by: Helm
 spec:
   minReadySeconds: 0
@@ -42,7 +42,7 @@ spec:
         runAsGroup: 1000
       containers:
         - name: kubernetes-ingress-controller
-          image: "registry.sighup.io/fury/haproxytech/kubernetes-ingress:3.2.4"
+          image: "registry.sighup.io/fury/haproxytech/kubernetes-ingress:3.2.8"
           imagePullPolicy: Always
           args:
             - --default-ssl-certificate=ingress-haproxy/haproxy-ingress-default-cert
@@ -54,9 +54,6 @@ spec:
             - --log=info
             - --prometheus
           securityContext:
-            runAsNonRoot: true
-            runAsUser: 1000
-            runAsGroup: 1000
             allowPrivilegeEscalation: false
             capabilities:
               drop:

--- a/katalog/haproxy/dual/internal/IngressClass-haproxy-internal.yaml
+++ b/katalog/haproxy/dual/internal/IngressClass-haproxy-internal.yaml
@@ -11,8 +11,8 @@ metadata:
   labels:
     app.kubernetes.io/name: kubernetes-ingress
     app.kubernetes.io/instance: haproxy-ingress
-    helm.sh/chart: kubernetes-ingress-1.47.4
-    app.kubernetes.io/version: "3.2.4"
+    helm.sh/chart: kubernetes-ingress-1.51.1
+    app.kubernetes.io/version: "3.2.8"
     app.kubernetes.io/managed-by: Helm
 spec:
   controller: haproxy.org/ingress-controller/haproxy-internal

--- a/katalog/haproxy/dual/internal/Job-haproxy-ingress-internal-crdjob.yaml
+++ b/katalog/haproxy/dual/internal/Job-haproxy-ingress-internal-crdjob.yaml
@@ -7,34 +7,39 @@
 apiVersion: batch/v1
 kind: Job
 metadata:
-  name: haproxy-ingress-external-crdjob-1
+  name: haproxy-ingress-internal-crdjob
   namespace: ingress-haproxy
   labels:
-    app.kubernetes.io/name: haproxy-ingress-external-proxy
+    app.kubernetes.io/name: haproxy-ingress-internal-proxy
     app.kubernetes.io/instance: haproxy-ingress
-    helm.sh/chart: kubernetes-ingress-1.47.4
-    app.kubernetes.io/version: "3.2.4"
+    helm.sh/chart: kubernetes-ingress-1.51.1
+    app.kubernetes.io/version: "3.2.8"
     app.kubernetes.io/managed-by: Helm
+  annotations:
+    argocd.argoproj.io/hook: Sync
+    argocd.argoproj.io/hook-delete-policy: HookSucceeded
+    helm.sh/hook: post-install,pre-upgrade
+    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
 spec:
   ttlSecondsAfterFinished: 600
   backoffLimit: 0
   template:
     metadata:
       labels:
-        app.kubernetes.io/name: haproxy-ingress-external-proxy
+        app.kubernetes.io/name: haproxy-ingress-internal-proxy
         app.kubernetes.io/instance: haproxy-ingress
         k8s-app: haproxy-ingress
-        type: external
+        type: internal
     spec:
       restartPolicy: Never
-      serviceAccountName: haproxy-ingress
+      serviceAccountName: haproxy-ingress-internal-crdjob
       securityContext:
         runAsNonRoot: true
         runAsUser: 1000
         runAsGroup: 1000
       containers:
         - name: crd
-          image: "registry.sighup.io/fury/haproxytech/kubernetes-ingress:3.2.4"
+          image: "registry.sighup.io/fury/haproxytech/kubernetes-ingress:3.2.8"
           imagePullPolicy: Always
           command:
             - /haproxy-ingress-controller

--- a/katalog/haproxy/dual/internal/Namespace-ingress-haproxy.yaml
+++ b/katalog/haproxy/dual/internal/Namespace-ingress-haproxy.yaml
@@ -11,6 +11,6 @@ metadata:
   labels:
     app.kubernetes.io/name: kubernetes-ingress
     app.kubernetes.io/instance: haproxy-ingress
-    helm.sh/chart: kubernetes-ingress-1.47.4
-    app.kubernetes.io/version: "3.2.4"
+    helm.sh/chart: kubernetes-ingress-1.51.1
+    app.kubernetes.io/version: "3.2.8"
     app.kubernetes.io/managed-by: Helm

--- a/katalog/haproxy/dual/internal/Service-haproxy-ingress-internal-metrics.yaml
+++ b/katalog/haproxy/dual/internal/Service-haproxy-ingress-internal-metrics.yaml
@@ -12,10 +12,10 @@ metadata:
   labels:
     app.kubernetes.io/name: kubernetes-ingress
     app.kubernetes.io/instance: haproxy-ingress
-    helm.sh/chart: kubernetes-ingress-1.47.4
-    app.kubernetes.io/version: "3.2.4"
+    helm.sh/chart: kubernetes-ingress-1.51.1
+    app.kubernetes.io/version: "3.2.8"
     app.kubernetes.io/managed-by: Helm
-  annotations:
+    app.kubernetes.io/component: metrics
 spec:
   type: ClusterIP
   ports:

--- a/katalog/haproxy/dual/internal/Service-haproxy-ingress-internal.yaml
+++ b/katalog/haproxy/dual/internal/Service-haproxy-ingress-internal.yaml
@@ -12,12 +12,11 @@ metadata:
   labels:
     app.kubernetes.io/name: kubernetes-ingress
     app.kubernetes.io/instance: haproxy-ingress
-    helm.sh/chart: kubernetes-ingress-1.47.4
-    app.kubernetes.io/version: "3.2.4"
+    helm.sh/chart: kubernetes-ingress-1.51.1
+    app.kubernetes.io/version: "3.2.8"
     app.kubernetes.io/managed-by: Helm
     k8s-app: haproxy-ingress
     type: internal
-  annotations:
 spec:
   type: NodePort
   externalTrafficPolicy: Local

--- a/katalog/haproxy/dual/internal/ServiceAccount-haproxy-ingress-internal-crdjob.yaml
+++ b/katalog/haproxy/dual/internal/ServiceAccount-haproxy-ingress-internal-crdjob.yaml
@@ -3,16 +3,21 @@
 # license that can be found in the LICENSE file.
 
 ---
-# Source: kubernetes-ingress/templates/controller-serviceaccount.yaml
+# Source: kubernetes-ingress/templates/controller-crdjob-rbac.yaml
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: haproxy-ingress
+  name: haproxy-ingress-internal-crdjob
   namespace: ingress-haproxy
   labels:
-    app.kubernetes.io/name: kubernetes-ingress
+    app.kubernetes.io/name: haproxy-ingress-internal-proxy
     app.kubernetes.io/instance: haproxy-ingress
     helm.sh/chart: kubernetes-ingress-1.51.1
     app.kubernetes.io/version: "3.2.8"
     app.kubernetes.io/managed-by: Helm
-automountServiceAccountToken: true
+  annotations:
+    helm.sh/hook: post-install,pre-upgrade
+    helm.sh/hook-weight: "-5"
+    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
+    argocd.argoproj.io/hook: Sync
+    argocd.argoproj.io/hook-delete-policy: HookSucceeded

--- a/katalog/haproxy/dual/internal/ServiceAccount-haproxy-ingress.yaml
+++ b/katalog/haproxy/dual/internal/ServiceAccount-haproxy-ingress.yaml
@@ -12,7 +12,7 @@ metadata:
   labels:
     app.kubernetes.io/name: kubernetes-ingress
     app.kubernetes.io/instance: haproxy-ingress
-    helm.sh/chart: kubernetes-ingress-1.47.4
-    app.kubernetes.io/version: "3.2.4"
+    helm.sh/chart: kubernetes-ingress-1.51.1
+    app.kubernetes.io/version: "3.2.8"
     app.kubernetes.io/managed-by: Helm
 automountServiceAccountToken: true

--- a/katalog/haproxy/dual/internal/ServiceMonitor-haproxy-ingress-internal.yaml
+++ b/katalog/haproxy/dual/internal/ServiceMonitor-haproxy-ingress-internal.yaml
@@ -12,8 +12,8 @@ metadata:
   labels:
     app.kubernetes.io/name: kubernetes-ingress
     app.kubernetes.io/instance: haproxy-ingress
-    helm.sh/chart: kubernetes-ingress-1.47.4
-    app.kubernetes.io/version: "3.2.4"
+    helm.sh/chart: kubernetes-ingress-1.51.1
+    app.kubernetes.io/version: "3.2.8"
     app.kubernetes.io/managed-by: Helm
     k8s-app: haproxy-ingress
 spec:
@@ -29,3 +29,4 @@ spec:
     matchLabels:
       app.kubernetes.io/name: kubernetes-ingress
       app.kubernetes.io/instance: haproxy-ingress
+      app.kubernetes.io/component: metrics

--- a/katalog/haproxy/dual/internal/kustomization.yaml
+++ b/katalog/haproxy/dual/internal/kustomization.yaml
@@ -22,7 +22,10 @@ resources:
   - Service-haproxy-ingress-internal-metrics.yaml
   - ServiceMonitor-haproxy-ingress-internal.yaml
   - IngressClass-haproxy-internal.yaml
-  - Job-haproxy-ingress-internal-crdjob-1.yaml
+  - ServiceAccount-haproxy-ingress-internal-crdjob.yaml
+  - ClusterRole-haproxy-ingress-internal-crdjob.yaml
+  - ClusterRoleBinding-haproxy-ingress-internal-crdjob.yaml
+  - Job-haproxy-ingress-internal-crdjob.yaml
 
 patches:
   - target:

--- a/katalog/haproxy/dual/kustomization.yaml
+++ b/katalog/haproxy/dual/kustomization.yaml
@@ -12,11 +12,31 @@ resources:
   - ../common
 
 patches:
-  # Remove duplicate CRD job - internal job is sufficient for both controllers
+  # Remove the duplicate external CRD job and its dedicated RBAC - the internal
+  # crdjob is sufficient to install the cluster-scoped CRDs for both controllers.
   - patch: |-
       $patch: delete
       apiVersion: batch/v1
       kind: Job
       metadata:
-        name: haproxy-ingress-external-crdjob-1
+        name: haproxy-ingress-external-crdjob
         namespace: ingress-haproxy
+  - patch: |-
+      $patch: delete
+      apiVersion: v1
+      kind: ServiceAccount
+      metadata:
+        name: haproxy-ingress-external-crdjob
+        namespace: ingress-haproxy
+  - patch: |-
+      $patch: delete
+      apiVersion: rbac.authorization.k8s.io/v1
+      kind: ClusterRole
+      metadata:
+        name: haproxy-ingress-external-crdjob
+  - patch: |-
+      $patch: delete
+      apiVersion: rbac.authorization.k8s.io/v1
+      kind: ClusterRoleBinding
+      metadata:
+        name: haproxy-ingress-external-crdjob

--- a/katalog/haproxy/single/ClusterRole-haproxy-ingress-crdjob.yaml
+++ b/katalog/haproxy/single/ClusterRole-haproxy-ingress-crdjob.yaml
@@ -1,0 +1,35 @@
+# Copyright (c) 2017-present SIGHUP s.r.l All rights reserved.
+# Use of this source code is governed by a BSD-style
+# license that can be found in the LICENSE file.
+
+---
+# Source: kubernetes-ingress/templates/controller-crdjob-rbac.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: haproxy-ingress-crdjob
+  labels:
+    app.kubernetes.io/name: haproxy-ingress-proxy
+    app.kubernetes.io/instance: haproxy-ingress
+    helm.sh/chart: kubernetes-ingress-1.51.1
+    app.kubernetes.io/version: "3.2.8"
+    app.kubernetes.io/managed-by: Helm
+  annotations:
+    helm.sh/hook: post-install,pre-upgrade
+    helm.sh/hook-weight: "-5"
+    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
+    argocd.argoproj.io/hook: Sync
+    argocd.argoproj.io/hook-delete-policy: HookSucceeded
+rules:
+  - apiGroups:
+      - "apiextensions.k8s.io"
+    resources:
+      - customresourcedefinitions
+    verbs:
+      - get
+      - list
+      - watch
+      - create
+      - update
+      - patch
+      - delete

--- a/katalog/haproxy/single/ClusterRole-haproxy-ingress.yaml
+++ b/katalog/haproxy/single/ClusterRole-haproxy-ingress.yaml
@@ -11,8 +11,8 @@ metadata:
   labels:
     app.kubernetes.io/name: kubernetes-ingress
     app.kubernetes.io/instance: haproxy-ingress
-    helm.sh/chart: kubernetes-ingress-1.47.4
-    app.kubernetes.io/version: "3.2.4"
+    helm.sh/chart: kubernetes-ingress-1.51.1
+    app.kubernetes.io/version: "3.2.8"
     app.kubernetes.io/managed-by: Helm
 rules:
   - apiGroups:
@@ -70,7 +70,7 @@ rules:
   - apiGroups:
       - core.haproxy.org
     resources:
-      - '*'
+      - "*"
     verbs:
       - get
       - list

--- a/katalog/haproxy/single/ClusterRoleBinding-haproxy-ingress-crdjob.yaml
+++ b/katalog/haproxy/single/ClusterRoleBinding-haproxy-ingress-crdjob.yaml
@@ -3,22 +3,28 @@
 # license that can be found in the LICENSE file.
 
 ---
-# Source: kubernetes-ingress/templates/clusterrolebinding.yaml
+# Source: kubernetes-ingress/templates/controller-crdjob-rbac.yaml
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: haproxy-ingress-internal
+  name: haproxy-ingress-crdjob
   labels:
-    app.kubernetes.io/name: kubernetes-ingress
+    app.kubernetes.io/name: haproxy-ingress-proxy
     app.kubernetes.io/instance: haproxy-ingress
     helm.sh/chart: kubernetes-ingress-1.51.1
     app.kubernetes.io/version: "3.2.8"
     app.kubernetes.io/managed-by: Helm
+  annotations:
+    helm.sh/hook: post-install,pre-upgrade
+    helm.sh/hook-weight: "-5"
+    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
+    argocd.argoproj.io/hook: Sync
+    argocd.argoproj.io/hook-delete-policy: HookSucceeded
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: haproxy-ingress-internal
+  name: haproxy-ingress-crdjob
 subjects:
   - kind: ServiceAccount
-    name: haproxy-ingress
+    name: haproxy-ingress-crdjob
     namespace: ingress-haproxy

--- a/katalog/haproxy/single/ClusterRoleBinding-haproxy-ingress.yaml
+++ b/katalog/haproxy/single/ClusterRoleBinding-haproxy-ingress.yaml
@@ -11,8 +11,8 @@ metadata:
   labels:
     app.kubernetes.io/name: kubernetes-ingress
     app.kubernetes.io/instance: haproxy-ingress
-    helm.sh/chart: kubernetes-ingress-1.47.4
-    app.kubernetes.io/version: "3.2.4"
+    helm.sh/chart: kubernetes-ingress-1.51.1
+    app.kubernetes.io/version: "3.2.8"
     app.kubernetes.io/managed-by: Helm
 roleRef:
   apiGroup: rbac.authorization.k8s.io

--- a/katalog/haproxy/single/ConfigMap-haproxy-ingress.yaml
+++ b/katalog/haproxy/single/ConfigMap-haproxy-ingress.yaml
@@ -12,8 +12,8 @@ metadata:
   labels:
     app.kubernetes.io/name: kubernetes-ingress
     app.kubernetes.io/instance: haproxy-ingress
-    helm.sh/chart: kubernetes-ingress-1.47.4
-    app.kubernetes.io/version: "3.2.4"
+    helm.sh/chart: kubernetes-ingress-1.51.1
+    app.kubernetes.io/version: "3.2.8"
     app.kubernetes.io/managed-by: Helm
 data:
   log-format: '%ci - - [%Tl] "%[capture.req.hdr(0)]" "%HM %HPO%HQ %HV" %ST %B "%[capture.req.hdr(1)]" "%[capture.req.hdr(2)]" %U %TR [%b] [] %si:%sp %B %Tr %ST %ID'

--- a/katalog/haproxy/single/DaemonSet-haproxy-ingress.yaml
+++ b/katalog/haproxy/single/DaemonSet-haproxy-ingress.yaml
@@ -12,8 +12,8 @@ metadata:
   labels:
     app.kubernetes.io/name: kubernetes-ingress
     app.kubernetes.io/instance: haproxy-ingress
-    helm.sh/chart: kubernetes-ingress-1.47.4
-    app.kubernetes.io/version: "3.2.4"
+    helm.sh/chart: kubernetes-ingress-1.51.1
+    app.kubernetes.io/version: "3.2.8"
     app.kubernetes.io/managed-by: Helm
 spec:
   minReadySeconds: 0
@@ -41,7 +41,7 @@ spec:
         runAsGroup: 1000
       containers:
         - name: kubernetes-ingress-controller
-          image: "registry.sighup.io/fury/haproxytech/kubernetes-ingress:3.2.4"
+          image: "registry.sighup.io/fury/haproxytech/kubernetes-ingress:3.2.8"
           imagePullPolicy: Always
           args:
             - --default-ssl-certificate=ingress-haproxy/haproxy-ingress-default-cert
@@ -53,9 +53,6 @@ spec:
             - --log=info
             - --prometheus
           securityContext:
-            runAsNonRoot: true
-            runAsUser: 1000
-            runAsGroup: 1000
             allowPrivilegeEscalation: false
             capabilities:
               drop:

--- a/katalog/haproxy/single/IngressClass-haproxy.yaml
+++ b/katalog/haproxy/single/IngressClass-haproxy.yaml
@@ -11,8 +11,8 @@ metadata:
   labels:
     app.kubernetes.io/name: kubernetes-ingress
     app.kubernetes.io/instance: haproxy-ingress
-    helm.sh/chart: kubernetes-ingress-1.47.4
-    app.kubernetes.io/version: "3.2.4"
+    helm.sh/chart: kubernetes-ingress-1.51.1
+    app.kubernetes.io/version: "3.2.8"
     app.kubernetes.io/managed-by: Helm
 spec:
   controller: haproxy.org/ingress-controller/haproxy

--- a/katalog/haproxy/single/Job-haproxy-ingress-crdjob.yaml
+++ b/katalog/haproxy/single/Job-haproxy-ingress-crdjob.yaml
@@ -7,14 +7,19 @@
 apiVersion: batch/v1
 kind: Job
 metadata:
-  name: haproxy-ingress-crdjob-1
+  name: haproxy-ingress-crdjob
   namespace: ingress-haproxy
   labels:
     app.kubernetes.io/name: haproxy-ingress-proxy
     app.kubernetes.io/instance: haproxy-ingress
-    helm.sh/chart: kubernetes-ingress-1.47.4
-    app.kubernetes.io/version: "3.2.4"
+    helm.sh/chart: kubernetes-ingress-1.51.1
+    app.kubernetes.io/version: "3.2.8"
     app.kubernetes.io/managed-by: Helm
+  annotations:
+    argocd.argoproj.io/hook: Sync
+    argocd.argoproj.io/hook-delete-policy: HookSucceeded
+    helm.sh/hook: post-install,pre-upgrade
+    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
 spec:
   ttlSecondsAfterFinished: 600
   backoffLimit: 0
@@ -26,14 +31,14 @@ spec:
         k8s-app: haproxy-ingress
     spec:
       restartPolicy: Never
-      serviceAccountName: haproxy-ingress
+      serviceAccountName: haproxy-ingress-crdjob
       securityContext:
         runAsNonRoot: true
         runAsUser: 1000
         runAsGroup: 1000
       containers:
         - name: crd
-          image: "registry.sighup.io/fury/haproxytech/kubernetes-ingress:3.2.4"
+          image: "registry.sighup.io/fury/haproxytech/kubernetes-ingress:3.2.8"
           imagePullPolicy: Always
           command:
             - /haproxy-ingress-controller

--- a/katalog/haproxy/single/Namespace-ingress-haproxy.yaml
+++ b/katalog/haproxy/single/Namespace-ingress-haproxy.yaml
@@ -11,7 +11,6 @@ metadata:
   labels:
     app.kubernetes.io/name: kubernetes-ingress
     app.kubernetes.io/instance: haproxy-ingress
-    helm.sh/chart: kubernetes-ingress-1.47.4
-    app.kubernetes.io/version: "3.2.4"
+    helm.sh/chart: kubernetes-ingress-1.51.1
+    app.kubernetes.io/version: "3.2.8"
     app.kubernetes.io/managed-by: Helm
-

--- a/katalog/haproxy/single/Service-haproxy-ingress-metrics.yaml
+++ b/katalog/haproxy/single/Service-haproxy-ingress-metrics.yaml
@@ -12,10 +12,10 @@ metadata:
   labels:
     app.kubernetes.io/name: kubernetes-ingress
     app.kubernetes.io/instance: haproxy-ingress
-    helm.sh/chart: kubernetes-ingress-1.47.4
-    app.kubernetes.io/version: "3.2.4"
+    helm.sh/chart: kubernetes-ingress-1.51.1
+    app.kubernetes.io/version: "3.2.8"
     app.kubernetes.io/managed-by: Helm
-  annotations:
+    app.kubernetes.io/component: metrics
 spec:
   type: ClusterIP
   ports:

--- a/katalog/haproxy/single/Service-haproxy-ingress.yaml
+++ b/katalog/haproxy/single/Service-haproxy-ingress.yaml
@@ -12,11 +12,10 @@ metadata:
   labels:
     app.kubernetes.io/name: kubernetes-ingress
     app.kubernetes.io/instance: haproxy-ingress
-    helm.sh/chart: kubernetes-ingress-1.47.4
-    app.kubernetes.io/version: "3.2.4"
+    helm.sh/chart: kubernetes-ingress-1.51.1
+    app.kubernetes.io/version: "3.2.8"
     app.kubernetes.io/managed-by: Helm
     k8s-app: haproxy-ingress
-  annotations:
 spec:
   type: NodePort
   externalTrafficPolicy: Local

--- a/katalog/haproxy/single/ServiceAccount-haproxy-ingress-crdjob.yaml
+++ b/katalog/haproxy/single/ServiceAccount-haproxy-ingress-crdjob.yaml
@@ -3,16 +3,21 @@
 # license that can be found in the LICENSE file.
 
 ---
-# Source: kubernetes-ingress/templates/controller-serviceaccount.yaml
+# Source: kubernetes-ingress/templates/controller-crdjob-rbac.yaml
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: haproxy-ingress
+  name: haproxy-ingress-crdjob
   namespace: ingress-haproxy
   labels:
-    app.kubernetes.io/name: kubernetes-ingress
+    app.kubernetes.io/name: haproxy-ingress-proxy
     app.kubernetes.io/instance: haproxy-ingress
     helm.sh/chart: kubernetes-ingress-1.51.1
     app.kubernetes.io/version: "3.2.8"
     app.kubernetes.io/managed-by: Helm
-automountServiceAccountToken: true
+  annotations:
+    helm.sh/hook: post-install,pre-upgrade
+    helm.sh/hook-weight: "-5"
+    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
+    argocd.argoproj.io/hook: Sync
+    argocd.argoproj.io/hook-delete-policy: HookSucceeded

--- a/katalog/haproxy/single/ServiceMonitor-haproxy-ingress.yaml
+++ b/katalog/haproxy/single/ServiceMonitor-haproxy-ingress.yaml
@@ -12,8 +12,8 @@ metadata:
   labels:
     app.kubernetes.io/name: kubernetes-ingress
     app.kubernetes.io/instance: haproxy-ingress
-    helm.sh/chart: kubernetes-ingress-1.47.4
-    app.kubernetes.io/version: "3.2.4"
+    helm.sh/chart: kubernetes-ingress-1.51.1
+    app.kubernetes.io/version: "3.2.8"
     app.kubernetes.io/managed-by: Helm
     k8s-app: haproxy-ingress
 spec:
@@ -29,3 +29,4 @@ spec:
     matchLabels:
       app.kubernetes.io/name: kubernetes-ingress
       app.kubernetes.io/instance: haproxy-ingress
+      app.kubernetes.io/component: metrics

--- a/katalog/haproxy/single/kustomization.yaml
+++ b/katalog/haproxy/single/kustomization.yaml
@@ -22,5 +22,8 @@ resources:
   - Service-haproxy-ingress-admin.yaml
   - ServiceMonitor-haproxy-ingress.yaml
   - IngressClass-haproxy.yaml
-  - Job-haproxy-ingress-crdjob-1.yaml
+  - ServiceAccount-haproxy-ingress-crdjob.yaml
+  - ClusterRole-haproxy-ingress-crdjob.yaml
+  - ClusterRoleBinding-haproxy-ingress-crdjob.yaml
+  - Job-haproxy-ingress-crdjob.yaml
   - ../common

--- a/katalog/haproxy/upgrade.sh
+++ b/katalog/haproxy/upgrade.sh
@@ -4,7 +4,7 @@
 # license that can be found in the LICENSE file.
 
 # Remember to change the helm chart version
-VERSION=1.47.4
+VERSION=1.51.1
 
 CHART_REPO="https://haproxytech.github.io/helm-charts"
 CHART_NAME="kubernetes-ingress"


### PR DESCRIPTION
### Summary 💡

Bump the HAProxy ingress controller from `v3.2.4` to `v3.2.8` (Helm chart `kubernetes-ingress` `1.47.4` → `1.51.1`). The image is mirrored to the SIGHUP registry via container-image-sync.

Closes:

Relates:
- sighupio/container-image-sync#410 (mirrors `haproxytech/kubernetes-ingress:3.2.8`)

### Description 📝

- `katalog/haproxy/upgrade.sh`: chart `1.51.1`; manifests regenerated for single + dual (internal/external).
- `MAINTENANCE.values.yaml`: image tag `3.2.8`; `--prometheus` now via `prometheus.enabled` (chart default) instead of `extraArgs` to avoid a duplicate flag; `pprof.enabled: false` to disable the controller debug endpoints enabled by default in the new chart.
- Chart restructured the CRD-installer Job (see Breaking Changes); kustomizations rewired and the dual delete-patch extended to drop the whole external crdjob unit.
- Docs: `katalog/haproxy/README.md` + `docs/releases/unreleased.md`.

### Breaking Changes 💔

The HAProxy chart bump restructured the CRD-installer Job:

- Renamed: `haproxy-ingress-crdjob-1` → `haproxy-ingress-crdjob` (dual: `haproxy-ingress-internal-crdjob-1` → `haproxy-ingress-internal-crdjob`).
- It now ships dedicated RBAC (`ServiceAccount`, `ClusterRole`, `ClusterRoleBinding` named `*-crdjob`) instead of reusing the controller's main ServiceAccount.

Consumers that patch or reference these resources by name (e.g. `nodeSelector`/`tolerations`, GitOps/RBAC tooling) must update the references. In dual mode only the `internal` CRD-installer runs (cluster-scoped CRDs installed once); patches must target `haproxy-ingress-internal-crdjob`.

### Tests performed 🧪

- [x] Local e2e suite (`mise run e2e`) on Kind **K8s v1.35.0** — **47/47 passed** (haproxy single/dual install, routing & isolation, IngressClass/DaemonSet checks)
- [x] `kustomize build` of `katalog/haproxy/{single,dual}` renders cleanly with image `:3.2.8`, single `--prometheus`, no `--pprof`
- [x] CI e2e tests green (all Kubernetes versions in the drone matrix)

### Future work 🔧

- When the distribution bumps this module, update `infra-nodes.yml.tpl` crdjob patch references (`crdjob-1` → `crdjob`).