### PR TITLE
feat: update external-dns to v0.21.0

### DIFF
--- a/katalog/external-dns/README.md
+++ b/katalog/external-dns/README.md
@@ -11,7 +11,7 @@ ExternalDNS synchronizes exposed Kubernetes Services and Ingresses with DNS prov
 
 ## Image repository and tag
 
-- ExternalDNS image: `k8s.gcr.io/external-dns/external-dns:v0.20.0`
+- ExternalDNS image: `k8s.gcr.io/external-dns/external-dns:v0.21.0`
 - ExternalDNS repo: [https://github.com/kubernetes-sigs/external-dns](https://github.com/kubernetes-sigs/external-dns)
 
 ## Deployment

--- a/katalog/external-dns/base/kustomization.yaml
+++ b/katalog/external-dns/base/kustomization.yaml
@@ -14,4 +14,4 @@ resources:
 images:
   - name: registry.k8s.io/external-dns/external-dns
     newName: registry.sighup.io/fury/external-dns/external-dns
-    newTag: v0.20.0
+    newTag: v0.21.0


### PR DESCRIPTION
### Summary 💡

Updates external-dns to 0.21.0. 

### Breaking Changes 💔

-  DigitalOcean provider is now removed. Users currently passing PROVIDER=digitalocean must migrate to the external provider plugin before upgrading.
- Unschedulable nodes are now ignored. If you are using --source=service, records will no longer be created for NodePort/ExternalIP services on nodes marked as unschedulable.

### Tests performed 🧪

- [x] e2e tests are passing

