### PR TITLE
docs: refactor module documentation, drop legacy Furyfile flow

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,28 @@ The module also includes additional tools like [Forecastle][forecastle-repo], a 
 
 ### Architecture
 
+The reference architecture used to deploy the Ingress Module is shown below:
+
+```mermaid
+flowchart LR
+    User([End users])
+    LB[Load Balancer]
+    subgraph cluster[Kubernetes Cluster]
+        direction LR
+        IC[Ingress Controller]
+        SVC[Service]
+        P1[Pod 1]
+        P2[Pod 2]
+        P3[Pod 3]
+        IC --> SVC
+        SVC --> P1
+        SVC --> P2
+        SVC --> P3
+    end
+    User --> LB
+    LB --> IC
+```
+
 - The traffic from end users arrives first at a Load Balancer that distributes the traffic between the available Ingress Controllers (usually, one for each availability zone).
 - Once the traffic reaches the Ingress Controller, the Ingress proxies the traffic to the Kubernetes service based on the URL path of the request.
 - The `service` is a Kubernetes abstraction that makes the traffic arrive at the pods where the actual application is running, usually using `iptables` rules.

--- a/README.md
+++ b/README.md
@@ -15,43 +15,40 @@
 
 <!-- <SD-DOCS> -->
 
-**Ingress Module** provides Ingress Controllers to expose services and TLS certificate management solutions for the [SIGHUP Distribution (SD)][kfd-repo].
+**Ingress Module** provides Ingress Controllers to expose services and TLS certificate management solutions for [SIGHUP Distribution (SD)][kfd-repo].
 
 If you are new to SD please refer to the [official documentation][kfd-docs] on how to get started with SD.
 
 ## Overview
 
-**Ingress Module** uses CNCF recommended, Cloud Native projects, such as [Ingress NGINX][ingress-nginx-docs] and [HAProxy Ingress Controller][haproxy-ingress-docs] as URL path-based routing reverse proxies and load balancers, and [cert-manager](https://github.com/jetstack/cert-manager) to automate the issuing and renewal of TLS certificates from various issuing sources.
+**Ingress Module** uses CNCF recommended, Cloud Native projects, such as [Ingress NGINX][ingress-nginx-docs] and [HAProxy Ingress Controller][haproxy-ingress-docs] as URL path-based routing reverse proxies and load balancers, and [cert-manager][cert-manager-repo] to automate the issuing and renewal of TLS certificates from various issuing sources.
 
 The module also includes additional tools like [Forecastle][forecastle-repo], a web-based global directory of all the services offered by your cluster, and [ExternalDNS][external-dns-docs] to manage DNS records natively from Kubernetes.
 
 ### Architecture
 
-The reference architecture used to deploy the Ingress Module is shown in the following figure:
-
-![Ingress Architecture](/docs/images/fury-ingress.png)
-
 - The traffic from end users arrives first at a Load Balancer that distributes the traffic between the available Ingress Controllers (usually, one for each availability zone).
 - Once the traffic reaches the Ingress Controller, the Ingress proxies the traffic to the Kubernetes service based on the URL path of the request.
 - The `service` is a Kubernetes abstraction that makes the traffic arrive at the pods where the actual application is running, usually using `iptables` rules.
 
-> For more information, please refer to Kubernetes Ingress [offiicial documentation][kubernetes-ingress]
+For more information, please refer to the Kubernetes Ingress [official documentation][kubernetes-ingress].
 
 ## Packages
 
-Ingress Module provides the following packages:
+The following packages are included in Ingress Module:
 
-| Package                                       | Version    | Description                                                                                                                   |
-| --------------------------------------------- | ---------- | ----------------------------------------------------------------------------------------------------------------------------- |
-| [nginx](katalog/nginx)                        | `v1.15.5-chainguard`  | The NGINX Ingress Controller for Kubernetes provides delivery services for Kubernetes applications.                           |
-| [dual-nginx](katalog/dual-nginx)              | `v1.15.5-chainguard`  | It deploys two identical NGINX ingress controllers but with two different scopes: public/external and private/internal.       |
-| [cert-manager](katalog/cert-manager)          | `v1.20.2`  | cert-manager is a Kubernetes add-on to automate the management and issuance of TLS certificates from various issuing sources. |
-| [external-dns](katalog/external-dns)          | `v0.21.0`  | external-dns allows you to manage DNS records natively from Kubernetes.                                                       |
-| [haproxy](katalog/haproxy)                    | `v3.2.8`   | The HAProxy Ingress Controller for Kubernetes, supporting single and dual deployment modes.                                   |
-| [dual-haproxy](katalog/haproxy)               | `v3.2.8`   | It deploys two HAProxy ingress controllers with two different scopes: public/external and private/internal.                   |
-| [forecastle](katalog/forecastle)              | `v1.0.159` | Forecastle gives you access to a control panel where you can see your ingresses and access them on Kubernetes.                |
-| [aws-cert-manager](modules/aws-cert-manager/) | -          | Terraform modules for managing IAM permissions on AWS for cert-manager                                                        |
-| [aws-external-dns](modules/aws-external-dns/) | -          | Terraform modules for managing IAM permissions on AWS for external-dns                                                        |
+| Package                                       | Version              | Description                                                                                                                   |
+| --------------------------------------------- | -------------------- | ----------------------------------------------------------------------------------------------------------------------------- |
+| [nginx](katalog/nginx)                        | `v1.15.5-chainguard` | The NGINX Ingress Controller for Kubernetes provides delivery services for Kubernetes applications.                           |
+| [dual-nginx](katalog/dual-nginx)              | `v1.15.5-chainguard` | Deploys two identical NGINX ingress controllers but with two different scopes: public/external and private/internal.          |
+| [cert-manager](katalog/cert-manager)          | `v1.20.2`            | cert-manager is a Kubernetes add-on to automate the management and issuance of TLS certificates from various issuing sources. |
+| [external-dns](katalog/external-dns)          | `v0.21.0`            | external-dns allows you to manage DNS records natively from Kubernetes.                                                       |
+| [haproxy](katalog/haproxy)                    | `v3.2.8`             | The HAProxy Ingress Controller for Kubernetes, supporting single and dual deployment modes.                                   |
+| [forecastle](katalog/forecastle)              | `v1.0.159`           | Forecastle gives you access to a control panel where you can see your ingresses and access them on Kubernetes.                |
+| [aws-cert-manager](modules/aws-cert-manager)  | `-`                  | Terraform module for managing IAM permissions on AWS for cert-manager.                                                        |
+| [aws-external-dns](modules/aws-external-dns)  | `-`                  | Terraform module for managing IAM permissions on AWS for external-dns.                                                        |
+
+Click on each package to see its full documentation.
 
 ## Compatibility
 
@@ -62,281 +59,80 @@ Ingress Module provides the following packages:
 | `1.34.x`           | :white_check_mark: | No known issues |
 | `1.35.x`           | :white_check_mark: | No known issues |
 
-Check the [compatibility matrix][compatibility-matrix] for additional information on previous releases of the module.
+Check the [compatibility matrix][compatibility-matrix] for additional information about previous releases of the module.
 
 ## Usage
 
-> [!NOTE]
-> Instructions below are for deploying the module using furyctl legacy, that required manual intervention.
->
-> Latest versions of furyctl automate the whole process and it is recommended to use the latest version of furyctl instead.
+**Ingress Module** is part of SIGHUP Distribution (SD) and is deployed automatically by [`furyctl`][furyctl-repo] when you create or update a cluster. You don't need to download, vendor or install its packages manually.
 
-### Prerequisites
+### Configuration
 
-| Tool                        | Version    | Description                                                                                                                                                    |
-| --------------------------- | ---------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| [furyctl][furyctl-repo]     | `>=0.25.0` | The recommended tool to download and manage SD modules and their packages. To learn more about `furyctl` read the [official documentation][furyctl-repo].     |
-| [kustomize][kustomize-repo] | `>=5.6.0`  | Packages are customized using `kustomize`. To learn how to create your customization layer with `kustomize`, please refer to the [repository][kustomize-repo]. |
-
-### Ingress Controller Choice
-
-The module supports two ingress controller implementations: **NGINX** and **HAProxy**. Both are available in single and dual deployment modes.
-
-The **Single Controller** package deploys one ingress controller that serves all traffic (internal and external).
-
-The **Dual Controller** package deploys two ingress controllers with different scopes:
-
-- The **internal** controller serves traffic inside the cluster's network, like users accessing via VPN to internal services (e.g., admin panels or other resources that you don't want to expose to the Internet).
-
-- The **external** controller serves traffic for applications exposed to the outside of the cluster (e.g., the frontend application to end-users).
-
-| Package | Single IngressClass | Dual IngressClasses                    |
-| ------- | ------------------- | -------------------------------------- |
-| NGINX   | `nginx`             | `external`, `internal`                 |
-| HAProxy | `haproxy`           | `haproxy-external`, `haproxy-internal` |
-
-### Default Configuration
-
-For both Single and Dual NGINX the Ingress Module module has the following default configuration:
-
-- Maximum allowed size of the client request body: `10m`
-- HTTP status code used in redirects: `301`
-- Metrics are scraped by Prometheus every `10s`
-- Validating Admission webhook that validates an ingress definition does not break NGINX configuration.
-
-Additionally, the following Prometheus Rules for [alerts][prometheus-alerts-page] are set up by default:
-
-| Parameter                           | Description                                                                                                                                         | Severity | Interval |
-| ----------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------- | -------- | :------: |
-| `NginxIngressDown`                  | This alert fires if Prometheus target discovery was not able to reach ingress-nginx-metrics in the last 15 minutes.                                 | critical |   15m    |
-| `NginxIngressFailureRate`           | This alert fires if the failure rate (the rate of 5xx responses) measured on a time window of 2 minutes was higher than 10% in the last 10 minutes. | critical |   10m    |
-| `NginxIngressFailedReload`          | This alert fires if the ingress' configuration reload failed in the last 10 minutes.                                                                | warning  |   10m    |
-| `NginxIngressLatencyTooHigh`        | This alert fires if the ingress 99th percentile latency was more than 5 seconds in the last 10 minutes.                                             | warning  |   10m    |
-| `NginxIngressLatencyTooHigh`        | This alert fires if the ingress 99th percentile latency was more than 10 seconds in the last 10 minutes.                                            | critical |   10m    |
-| `NginxIngressCertificateExpiration` | This alert fires if the certificate for a given host is expiring in less than 7 days.                                                               | warning  |          |
-| `NginxIngressCertificateExpiration` | This alert fires if the certificate for a given host is expiring in less than 1 day.                                                                | critical |          |
-
-### Deployment
-
-#### Certificates automation with cert-manager
-
-Ingress Module cert-manager package is the defacto tool to manage certificates in Kubernetes. It manages the issuing and automatic renewal of certificates for the domains served by the Ingress Controller.
-
-The package's default configuration includes:
-
-- Let's Encrypt as the default certificates issuer, both staging and production.
-- `ClusterIssuer` as the default issuer kind
-
-To deploy the `cert-manager` package:
-
-1. Add the package to your bases inside the `Furyfile.yml`:
+The module is deployed with sensible defaults. Configuration is **optional**: you can customize its packages under `spec.distribution.modules.ingress` in your `furyctl.yaml`. If you omit the block, the defaults are applied.
 
 ```yaml
-bases:
-  - name: ingress/dual-nginx
-    version: "v5.1.0"
-  - name: ingress/cert-manager
-    version: "v5.1.0"
-```
-
-2. Execute `furyctl vendor -H` to download the packages
-
-3. Inspect the download packages under `./vendor/katalog/ingress/cert-manager`.
-
-4. Define a `kustomization.yaml` that includes the `./vendor/katalog/ingress/cert-manager` directory as resource.
-
-```yaml
-resources:
-  - ./vendor/katalog/ingress/cert-manager
-```
-
-For the `dual-nginx` you will need to patch the `ClusterIssuer` resource with the right ingress class:
-
-```yml
----
-patchesJson6902:
-  - target:
-      group: cert-manager.io
-      version: v1
-      kind: ClusterIssuer
-      name: letsencrypt-staging
-    path: patches/dual-nginx.yml
-  - target:
-      group: cert-manager.io
-      version: v1
-      kind: ClusterIssuer
-      name: letsencrypt-prod
-    path: patches/dual-nginx.yml
-```
-
-and in the `patches/dual-nginx.yml`:
-
-```yml
----
-- op: "replace"
-  path: "/spec/acme/solvers/0/http01/ingress/class"
-  value: "external"
-```
-
-5. Finally, execute the following command to deploy the package:
-
-```shell
-kustomize build . | kubectl apply -f -
-```
-
-#### NGINX Ingress Controller
-
-> ⚠️ You'll need to have deployed [`cert-manager`](../cert-manager/) first, the validating webhook needs to have TLS communication with the API server.
-
-1. Once you selected the type of ingress you want to deploy (`nginx` or `dual-nginx`) the next step is to specify this in a `Furyfile.yml`:
-
-Single Ingress:
-
-```yaml
-bases:
-  - name: ingress/nginx
-    version: "v5.1.0"
-```
-
-Dual Ingress:
-
-> `dual-nginx` depends on the `nginx` package, so we need to download both of them.
-
-```yaml
-bases:
-  - name: ingress/nginx
-    version: "v5.1.0"
-  - name: ingress/dual-nginx
-    version: "v5.1.0"
-```
-
-> See `furyctl` [documentation][furyctl-repo] for additional details about `Furyfile.yml` format.
-
-2. Execute `furyctl legacy vendor -H` to download the packages
-
-3. Inspect the download packages under `./vendor/katalog/ingress/`.
-
-4. Define a `kustomization.yaml` that includes the `./vendor/katalog/ingress` directory as resource.
-
-```yaml
-resources:
-  - ./vendor/katalog/ingress
-```
-
-5. Apply the necessary patches. You can find a list of common customization [here](#common-customizations).
-
-6. To deploy the packages to your cluster, execute:
-
-```bash
-kustomize build . | kubectl apply -f -
-```
-
-Your are now ready to expose your applications using Kubernetes `Ingress` objects.
-
-### Common customizations
-
-`nginx` package is deployed by default as a `DaemonSet`, meaning that it will deploy 1 ingress-controller pod on every worker node.
-
-This is probably NOT what you want, standard Fury clusters have at least 1 `infra` node (nodes that are dedicated to run Fury infrastructural components, like Prometheus, elasticsearch, and the ingress controllers).
-
-If your cluster has `infra` nodes you should patch the daemonset adding the `NodeSelector` for the `infra` nodes to the Ingress `DaemonSet`. You can do this using the following kustomize patch:
-
-```yaml
----
-apiVersion: apps/v1
-kind: DaemonSet
-metadata:
-  name: nginx-ingress-controller-external
+apiVersion: kfd.sighup.io/v1alpha2
+kind: KFDDistribution
 spec:
-  template:
-    spec:
-      nodeSelector:
-        node-kind.sighup.io/infra: ""
----
-apiVersion: apps/v1
-kind: DaemonSet
-metadata:
-  name: nginx-ingress-controller-internal
+  distribution:
+    modules:
+      ingress:
+        baseDomain: example.dev
+        nginx:
+          type: dual
+          tls:
+            provider: certManager
+        certManager:
+          clusterIssuer:
+            name: letsencrypt
+            email: example@sighup.io
+            type: http01
+        forecastle: {}
+```
+
+To use HAProxy as the ingress controller instead of NGINX, configure the `haproxy` block (and set `nginx.type: none`):
+
+```yaml
+apiVersion: kfd.sighup.io/v1alpha2
+kind: KFDDistribution
 spec:
-  template:
-    spec:
-      nodeSelector:
-        node-kind.sighup.io/infra: ""
+  distribution:
+    modules:
+      ingress:
+        baseDomain: example.dev
+        nginx:
+          type: none
+        haproxy:
+          type: dual
+          tls:
+            provider: certManager
+        certManager:
+          clusterIssuer:
+            name: letsencrypt
+            email: example@sighup.io
+            type: http01
+        forecastle: {}
 ```
 
-If you don't have infra nodes and you don't want to run ingress-controllers on all your worker nodes, you should probably label some nodes and adjust the previous `NodeSelector` accordingly.
+See the configuration reference for your cluster kind for the full list of available options: [EKSCluster][schema-reference-eks], [KFDDistribution][schema-reference-kfd] or [OnPremises][schema-reference-onprem].
 
-#### Applications directory with Forecastle
-
-Forecastle list all the annotated ingress (applications) that exists in your cluster with an icon grouped by namespace, in a nice web UI. It lets you search, personalize the header for the landing page (title and colors), it lets you list custom ingress and add more details to each entry.
-
-Use Forecastle as your cluster entry point to discover the running applications easily.
-
-To deploy the `forecastle` package:
-
-1. Add the package to your bases inside the `Furyfile.yml`:
-
-```yaml
-bases:
-  - name: ingress/dual-nginx
-    version: "v5.1.0"
-  - name: ingress/cert-manager
-    version: "v5.1.0"
-  - name: ingress/forecastle
-    version: "v5.1.0"
-```
-
-2. Execute `furyctl legacy vendor -H` to download the packages
-
-3. Inspect the download packages under `./vendor/katalog/ingress/forecastle`.
-
-4. Define a `kustomization.yaml` that includes the `./vendor/katalog/ingress/forecastle` directory as resource.
-
-```yaml
-resources:
-  - ./vendor/katalog/ingress/forecastle
-```
-
-5. Finally, execute the following command to deploy the package:
-
-```shell
-kustomize build . | kubectl apply -f -
-```
-
-##### Basic usage
-
-Forecastle looks for specific annotations on ingresses objects.
-
-Add the following annotations to your ingresses to be discovered by Forecastle:
-
-| Annotation                                   | Description                                                                                                                                               | Required |
-| -------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------- | -------- |
-| `forecastle.stakater.com/expose`             | Add this with value `true` to the ingress of the app you want to show in Forecastle                                                                       | `true`   |
-| `forecastle.stakater.com/icon`               | Icon/Image URL of the application; An icons/logos/images collection repo [Icons][forecastle-icons]                                                        | `false`  |
-| `forecastle.stakater.com/appName`            | A custom name for your application. Default is the name of the ingress                                                                                    | `false`  |
-| `forecastle.stakater.com/group`              | A custom group name. Use if you want the application to show in a different group than the namespace it belongs to                                        | `false`  |
-| `forecastle.stakater.com/instance`           | A comma-separated list of name/s of the forecastle instance/s where you want this application to appear. Use when you have multiple forecastle dashboards | `false`  |
-| `forecastle.stakater.com/url`                | A URL for the forecastle app (This will override the ingress URL). It _must_ begin with a scheme i.e. `http://` or `https://`                             | `false`  |
-| `forecastle.stakater.com/properties`         | A comma separate list of key-value pairs for the properties. This will appear as an expandable list for the app                                           | `false`  |
-| `forecastle.stakater.com/network-restricted` | Specify whether the application is network restricted or not (true or false)                                                                              | `false`  |
-
-> See Forecastle [official repository][forecastle-repository] for more details.
+To install SD from scratch, follow the [Getting started][getting-started] guide.
 
 <!-- Links -->
 
+[kfd-repo]: https://github.com/sighupio/distribution
 [furyctl-repo]: https://github.com/sighupio/furyctl
-[kfd-repo]: https://github.com/sighupio/fury-distribution
-[kustomize-repo]: https://github.com/kubernetes-sigs/kustomize
-[kfd-docs]: https://docs.kubernetesfury.com/docs/distribution/
-[compatibility-matrix]: https://github.com/sighupio/fury-kubernetes-ingress/blob/main/docs/COMPATIBILITY_MATRIX.md
+[kfd-docs]: https://docs.sighup.io/docs/distribution/
+[schema-reference-eks]: https://docs.sighup.io/docs/reference/ekscluster#specdistributionmodulesingress
+[schema-reference-kfd]: https://docs.sighup.io/docs/reference/kfddistribution#specdistributionmodulesingress
+[schema-reference-onprem]: https://docs.sighup.io/docs/reference/onpremises#specdistributionmodulesingress
+[getting-started]: https://docs.sighup.io/docs/getting-started/
+[compatibility-matrix]: https://github.com/sighupio/module-ingress/blob/main/docs/COMPATIBILITY_MATRIX.md
 [kubernetes-ingress]: https://kubernetes.io/docs/concepts/services-networking/ingress/
-[forecastle-repo]: https://github.com/stakater/Forecastle
-[forecastle-icons]: https://github.com/stakater/ForecastleIcons
-[forecastle-repository]: https://github.com/stakater/Forecastle/blob/v1.0.159/README.md
 [ingress-nginx-docs]: https://github.com/kubernetes/ingress-nginx
 [haproxy-ingress-docs]: https://github.com/haproxytech/kubernetes-ingress
+[cert-manager-repo]: https://github.com/cert-manager/cert-manager
 [external-dns-docs]: https://github.com/kubernetes-sigs/external-dns
-[prometheus-alerts-page]: https://prometheus.io/docs/prometheus/latest/configuration/alerting_rules/
+[forecastle-repo]: https://github.com/stakater/Forecastle
 
 <!-- </SD-DOCS> -->
 
@@ -344,14 +140,14 @@ Add the following annotations to your ingresses to be discovered by Forecastle:
 
 ## Contributing
 
-Before contributing, please read first the [Contributing Guidelines](docs/CONTRIBUTING.md).
+Before contributing, please read first the [Contributing Guidelines](https://github.com/sighupio/distribution/blob/main/docs/CONTRIBUTING.md).
 
 ### Reporting Issues
 
-In case you experience any problems with the module, please [open a new issue](https://github.com/sighupio/fury-kubernetes-ingress/issues/new/choose).
+In case you experience any problem with the module, please [open a new issue](https://github.com/sighupio/module-ingress/issues/new/choose).
 
 ## License
 
-This module is open-source and it's released under the following [LICENSE](LICENSE)
+This module is open-source and it's released under the following [LICENSE](LICENSE).
 
 <!-- </FOOTER> -->

--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ Check the [compatibility matrix][compatibility-matrix] for additional informatio
 
 ### Configuration
 
-The module is deployed with sensible defaults. Configuration is **optional**: you can customize its packages under `spec.distribution.modules.ingress` in your `furyctl.yaml`. If you omit the block, the defaults are applied.
+You configure the module under `spec.distribution.modules.ingress` in your `furyctl.yaml`. You set the `baseDomain` and choose the ingress controller via `nginx.type` (or `haproxy.type`): `single`, `dual`, or `none` to disable it. The other fields are optional and fall back to sensible defaults.
 
 ```yaml
 apiVersion: kfd.sighup.io/v1alpha2

--- a/katalog/cert-manager/README.md
+++ b/katalog/cert-manager/README.md
@@ -2,89 +2,30 @@
 
 <!-- <SD-DOCS> -->
 
-cert-manager is an automation tool to manage and issue TLS certificates from various issuing resources in a Kubernetes native way. It ensures that certificates are valid and attempts to renew them before expiry.
+## Overview
 
-This package deploys cert-manager to be used with [Let's Encrypt](https://letsencrypt.org/) as the Certificate Authority.
+cert-manager is a Kubernetes add-on that automates the management and issuance of TLS certificates from various issuing sources. It ensures certificates are valid and attempts to renew them before they expire. In the Ingress Module it is configured to use [Let's Encrypt][lets-encrypt] as the Certificate Authority, with `ClusterIssuer` as the default issuer kind.
 
-## Requirements
+## Upstream project
 
-- Kubernetes `1.32` -> `1.35`
-- Kustomize >= `v5.6.0`
-
-## Image repository and tag
-
-- Cert Manager image: `quay.io/jetstack/cert-manager-controller:v1.20.2`
-- Cert Manager repo: [https://github.com/jetstack/cert-manager](https://github.com/jetstack/cert-manager)
-- Cert Manager documentation: [https://cert-manager.io/docs/](https://cert-manager.io/docs/)
-
-## Configuration
-
-`cert-manager` is deployed with the following configuration:
-
-- The default issuer kind is `ClusterIssuer`
-- The default issuer is `letsencrypt`
+This package is based on the upstream [cert-manager][cert-manager-github].
 
 ## Deployment
 
-To deploy the `cert-manager` package:
+This package is deployed as part of **Ingress Module** when you create a cluster with `furyctl`.
 
-1. Add the package to your bases inside the `Furyfile.yml`:
+You can customize it under `spec.distribution.modules.ingress.certManager` in your `furyctl.yaml`. See the [module documentation](../../README.md) and the configuration reference ([EKSCluster][schema-reference-eks], [KFDDistribution][schema-reference-kfd], [OnPremises][schema-reference-onprem]) for the available options.
 
-```yaml
-resources:
-  - name: ingress/dual-nginx
-    version: "v5.1.0"
-  - name: ingress/cert-manager
-    version: "v5.1.0"
-```
+<!-- Links -->
 
-2. Execute `furyctl legacy vendor -H` to download the packages
-
-3. Inspect the download packages under `./vendor/katalog/ingress/cert-manager`.
-
-4. Define a `kustomization.yaml` that includes the `./vendor/katalog/ingress/cert-manager` directory as resource.
-
-```yaml
-resources:
-- ./vendor/katalog/ingress/cert-manager
-```
-
-For the `dual-nginx` you will need to patch the `ClusterIssuer` resource with the right ingress class:
-
-```yml
----
-patchesJson6902:
-    - target:
-          group: cert-manager.io
-          version: v1
-          kind: ClusterIssuer
-          name: letsencrypt-staging
-      path: patches/dual-nginx.yml
-    - target:
-          group: cert-manager.io
-          version: v1
-          kind: ClusterIssuer
-          name: letsencrypt-prod
-      path: patches/dual-nginx.yml
-```
-
-and in the `patches/dual-nginx.yml`:
-
-```yml
----
-- op: "replace"
-  path: "/spec/acme/solvers/0/http01/ingress/class"
-  value: "external"
-```
-
-5. Finally, execute the following command to deploy the package:
-
-```shell
-kustomize build . | kubectl apply -f -
-```
+[cert-manager-github]: https://github.com/cert-manager/cert-manager
+[lets-encrypt]: https://letsencrypt.org/
+[schema-reference-eks]: https://docs.sighup.io/docs/reference/ekscluster#specdistributionmodulesingress
+[schema-reference-kfd]: https://docs.sighup.io/docs/reference/kfddistribution#specdistributionmodulesingress
+[schema-reference-onprem]: https://docs.sighup.io/docs/reference/onpremises#specdistributionmodulesingress
 
 <!-- </SD-DOCS> -->
 
 ## License
 
-For license details please see [LICENSE](../../LICENSE).
+For license details please see [LICENSE](../../LICENSE)

--- a/katalog/dual-nginx/README.md
+++ b/katalog/dual-nginx/README.md
@@ -2,120 +2,28 @@
 
 <!-- <SD-DOCS> -->
 
-Ingress NGINX is an Ingress Controller for [NGINX][nginx-page] webserver and reverse proxy, it manages NGINX in a Kubernetes native manner. This package deploys 2 NGINX Controllers, one with ingress class `external` to serve public traffic, and one with ingress class `internal` to serve internal traffic.
+## Overview
 
-## Requirements
+Ingress NGINX is an Ingress Controller for the [NGINX][nginx-page] web server and reverse proxy, managing NGINX in a Kubernetes native manner. This package deploys two NGINX controllers: one with ingress class `external` to serve public traffic, and one with ingress class `internal` to serve internal traffic. The default configuration sets a maximum client request body size of `10m`, a `301` redirect status code, Prometheus metrics scraping, and a validating admission webhook for ingress definitions.
 
-- Kubernetes >= `1.30.0`
-- Kustomize >= `v5.6.0`
-- [`cert-manager`](../cert-manager)
+## Upstream project
 
-## Image repository and tag
-
-- Ingress NGINX image: `registry.sighup.io/fury/ingress-nginx/controller:v1.15.5-chainguard` (built in-house from the Chainguard-maintained fork)
-- Ingress NGINX upstream repo (archived): [https://github.com/kubernetes/ingress-nginx](https://github.com/kubernetes/ingress-nginx)
-- Ingress NGINX fork repo (maintained): [https://github.com/chainguard-forks/ingress-nginx](https://github.com/chainguard-forks/ingress-nginx)
-
-## Configuration
-
-Ingress NGINX Double is deployed with the following default configuration:
-
-- Maximum allowed size of the client request body: `10m`
-- HTTP status code used in redirects: `301`
-- Metrics are scraped by Prometheus every `10s`
-- Validating Admission webhook that validates an ingress definition does not break NGINX configuration.
+This package is based on the upstream [Ingress NGINX][nginx-github]. SIGHUP rebuilds the controller on top of [Chainguard][chainguard] hardened, minimal container images (hence the `-chainguard` image tags), so the deployed images are not the upstream ones.
 
 ## Deployment
 
-1. Add the module to your `Furyfile.yml`:
+This package is deployed as part of **Ingress Module** when you create a cluster with `furyctl`.
 
-> `dual-nginx` depends on the `nginx` package, so we need to download both of them.
-
-```yaml
-bases:
-  - name: ingress/nginx
-    version: "v5.0.0"
-  - name: ingress/dual-nginx
-    version: "v5.0.0"
-```
-
-> See `furyctl` [documentation][furyctl-repo] for additional details about `Furyfile.yml` format.
-
-2. Execute `furyctl legacy vendor -H` to download the packages
-
-3. Inspect the download packages under `./vendor/katalog/ingress/dual-nginx`.
-
-4. Define a `kustomization.yaml` that includes the `./vendor/katalog/ingress/dual-nginx` directory as resource.
-
-```yaml
-resources:
-  - ./vendor/katalog/ingress/dual-nginx
-```
-
-5. Apply the necessary patches. You can find a list of common customization [here](#common-customizations).
-
-6. To deploy the packages to your cluster, execute:
-
-```bash
-kustomize build . | kubectl apply -f -
-```
-
-Your are now ready to expose your applications using Kubernetes `Ingress` objects.
-
-## Common customizations
-
-`nginx` package is deployed by default as a `DaemonSet`, meaning that it will deploy 1 ingress-controller pod on every worker node.
-
-This is probably NOT what you want, standard Fury clusters have at least 1 `infra` node (nodes that are dedicated to run Fury infrastructural components, like Prometheus, elasticsearch, and the ingress controllers).
-
-If your cluster has `infra` nodes you should patch the daemonset adding the `NodeSelector` for the `infra` nodes to the Ingress `DaemonSet`. You can do this using the following kustomize patch:
-
-```yaml
----
-apiVersion: apps/v1
-kind: DaemonSet
-metadata:
-  name: ingress-nginx-controller-external
-spec:
-  template:
-    spec:
-      nodeSelector:
-        node-kind.sighup.io/infra: ""
----
-apiVersion: apps/v1
-kind: DaemonSet
-metadata:
-  name: ingress-nginx-controller-internal
-spec:
-  template:
-    spec:
-      nodeSelector:
-        node-kind.sighup.io/infra: ""
-```
-
-If you don't have infra nodes and you don't want to run ingress-controllers on all your worker nodes, you should probably label some nodes and adjust the previous `NodeSelector` accordingly.
-
-## Alerts
-
-Followings Prometheus [alerts][prometheus-alerts] are already defined for this package.
-
-### ingress-nginx.rules
-
-| Parameter                           | Description                                                                                                                                         | Severity | Interval |
-| ----------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------- | -------- | :------: |
-| `NginxIngressDown`                  | This alert fires if Prometheus target discovery was not able to reach ingress-nginx-metrics in the last 15 minutes.                                 | critical |   15m    |
-| `NginxIngressFailureRate`           | This alert fires if the failure rate (the rate of 5xx responses) measured on a time window of 2 minutes was higher than 10% in the last 10 minutes. | critical |   10m    |
-| `NginxIngressFailedReload`          | This alert fires if the ingress' configuration reload failed in the last 10 minutes.                                                                | warning  |   10m    |
-| `NginxIngressLatencyTooHigh`        | This alert fires if the ingress 99th percentile latency was more than 5 seconds in the last 10 minutes.                                             | warning  |   10m    |
-| `NginxIngressLatencyTooHigh`        | This alert fires if the ingress 99th percentile latency was more than 10 seconds in the last 10 minutes.                                            | critical |   10m    |
-| `NginxIngressCertificateExpiration` | This alert fires if the certificate for a given host is expiring in less than 7 days.                                                               | warning  |          |
-| `NginxIngressCertificateExpiration` | This alert fires if the certificate for a given host is expiring in less than 1 day.                                                                | critical |          |
+You can customize it under `spec.distribution.modules.ingress.nginx` in your `furyctl.yaml`. See the [module documentation](../../README.md) and the configuration reference ([EKSCluster][schema-reference-eks], [KFDDistribution][schema-reference-kfd], [OnPremises][schema-reference-onprem]) for the available options.
 
 <!-- Links -->
 
-[furyctl-repo]: https://github.com/sighupio/furyctl
 [nginx-page]: https://nginx.org
-[prometheus-alerts]: https://prometheus.io/docs/prometheus/latest/configuration/alerting_rules/
+[nginx-github]: https://github.com/kubernetes/ingress-nginx
+[chainguard]: https://www.chainguard.dev
+[schema-reference-eks]: https://docs.sighup.io/docs/reference/ekscluster#specdistributionmodulesingress
+[schema-reference-kfd]: https://docs.sighup.io/docs/reference/kfddistribution#specdistributionmodulesingress
+[schema-reference-onprem]: https://docs.sighup.io/docs/reference/onpremises#specdistributionmodulesingress
 
 <!-- </SD-DOCS> -->
 

--- a/katalog/external-dns/README.md
+++ b/katalog/external-dns/README.md
@@ -1,81 +1,22 @@
-# ExternalDNS package
+# ExternalDNS
 
 <!-- <SD-DOCS> -->
 
-ExternalDNS synchronizes exposed Kubernetes Services and Ingresses with DNS providers.
+## Overview
 
-## Requirements
+ExternalDNS synchronizes exposed Kubernetes Services and Ingresses with DNS providers. In the Ingress Module it is deployed in two flavors, one for "private" records and one for "public" records, and it relies on cloud resources (for example an IAM role and Route53 zones on AWS) that the distribution provisions automatically through the accompanying Terraform modules.
 
-- Kubernetes >= `1.21.0`
-- Kustomize >= `v5.6.0`
+## Upstream project
 
-## Image repository and tag
-
-- ExternalDNS image: `k8s.gcr.io/external-dns/external-dns:v0.21.0`
-- ExternalDNS repo: [https://github.com/kubernetes-sigs/external-dns](https://github.com/kubernetes-sigs/external-dns)
+This package is based on the upstream [ExternalDNS][external-dns-github].
 
 ## Deployment
 
-This package provides two deployments of external-dns, one for "private" records and one for "public" records. The only thing that differs between the two packages is the
-suffix used on kustomize to generate all the resources.
+This package is deployed and managed internally as part of **Ingress Module** when you create a cluster with `furyctl`. It is not meant to be configured directly: it has no dedicated options in the `furyctl.yaml` schema, and its DNS providers and credentials (for example the AWS IAM role and Route53 zones) are derived from your cluster configuration and provisioned automatically by the distribution. See the [module documentation](../../README.md) to learn how the Ingress Module is installed.
 
-The package itself cannot be used without patches, and in this module we provide terraform modules to generate the required cloud resources and kustomize patches.
+<!-- Links -->
 
-You can deploy ExternalDNS in your cluster by including the package in your kustomize project:
-
-`kustomization.yaml` file extract:
-```yaml
-...
-
-resources:
-  - katalog/external-dns/private
-  - katalog/external-dns/public
-
-...
-```
-
-Refer to the Terraform module [aws-eternal-dns](../../modules/aws-external-dns) to create the
-IAM role and the required Kustomize patches automatically. For now the only supported cloud provider is AWS with Route53.
-
-If you want to still create everything manually without using our Terraform Module, you need to patch the service accounts follows:
-
-`sa-patch.yaml`
-```yaml
----
-apiVersion: v1
-kind: ServiceAccount
-metadata:
-  annotations:
-    eks.amazonaws.com/role-arn: arn:aws:iam::123456789123:role/your-role-name-public
-  name: external-dns-public
-  namespace: external-dns
----
-apiVersion: v1
-kind: ServiceAccount
-metadata:
-  annotations:
-    eks.amazonaws.com/role-arn: arn:aws:iam::123456789123:role/your-role-name-private
-  name: external-dns-private
-  namespace: external-dns
-```
-
-and then add on the `kustomization.yaml` file the patches:
-
-`kustomization.yaml` file extract:
-```yaml
-...
-
-patchesStrategicMerge:
-  - sa-patch.yaml
-
-...
-```
-
-You can then apply your kustomize project by running the following command:
-
-```bash
-kustomize build | kubectl apply -f -
-```
+[external-dns-github]: https://github.com/kubernetes-sigs/external-dns
 
 <!-- </SD-DOCS> -->
 

--- a/katalog/forecastle/README.md
+++ b/katalog/forecastle/README.md
@@ -2,79 +2,30 @@
 
 <!-- <SD-DOCS> -->
 
-[Forecastle][forecastle-page] provides a handy dashboard to show all the applications running on Kubernetes exposed through an Ingress.
+## Overview
 
-## Requirements
+[Forecastle][forecastle-page] provides a handy dashboard that lists all the applications running on Kubernetes and exposed through an Ingress, grouped by namespace. It acts as a cluster entry point to discover running applications. Forecastle discovers applications through annotations on Ingress objects (for example `forecastle.stakater.com/expose: "true"`) and through the `ForecastleApp` custom resource.
 
-- Kubernetes >= `1.20.0`
-- Kustomize >= `v5.6.0`
+## Upstream project
 
-## Image repository and tag
-
-- Forecastle image: `docker.io/stakater/forecastle:v1.0.159`
-- Forecastle repo: [https://github.com/stakater/Forecastle](https://github.com/stakater/Forecastle)
-
-## Configuration
-
-Forecastle is deployed with the following configuration:
-
-- watch every namespace for ingresses
-- CRD support disabled
-- unprivileged Pod
-- hardened RBAC
-- constrained resources
+This package is based on the upstream [Forecastle][forecastle-github].
 
 ## Deployment
 
-Forecastle can be deployed by running the following command at the root of the project:
+This package is deployed as part of **Ingress Module** when you create a cluster with `furyctl`.
 
-```shell
-kustomize build katalog/forecastle | kubectl apply -f -
-```
-
-### Usage
-
-Once deployed, to have an ingress show up in the dashboard provided by Forecastle run:
-
-```shell
-kubectl annotate ingress <YOUR_INGRESS> "forecastle.stakater.com/expose=true" --overwrite
-```
-
-#### `ForecastleApp` CRD
-
-You can now create custom resources to add apps to forecastle dynamically. This decouples the application configuration from Ingresses as well as forecastle config. You can create the custom resource `ForecastleApp` like the following:
-
-#### example CR
-
-```yaml
-apiVersion: forecastle.stakater.com/v1alpha1
-kind: ForecastleApp
-metadata:
-  name: sighup-example-app
-  namespace: forecastle
-  labels:
-    app: forecastle
-spec:
-  name: sighup
-  group: dev
-  icon: https://raw.githubusercontent.com/sighupio/fury-distribution/main/docs/assets/fury-epta-white.png
-  url: https://sighup.io/
-  networkRestricted: false
-  properties:
-    Version: "1"
-```
-
-##### Automatically discover URL's from Kubernetes Resources
-
-Forecastle supports discovering URL's ForecastleApp CRD from the following resources:
-
-- Ingress
-
-## Important notes
-
-The `kubernetes.io/ingress.class` annotation is required by Forecastle to have the ingress displayed in the dashboard, therefore you need to add such annotation to all your ingresses even when using a single ingress controller.
+You can customize it under `spec.distribution.modules.ingress.forecastle` in your `furyctl.yaml`. See the [module documentation](../../README.md) and the configuration reference ([EKSCluster][schema-reference-eks], [KFDDistribution][schema-reference-kfd], [OnPremises][schema-reference-onprem]) for the available options.
 
 <!-- Links -->
+
 [forecastle-page]: https://github.com/stakater/Forecastle
+[forecastle-github]: https://github.com/stakater/Forecastle
+[schema-reference-eks]: https://docs.sighup.io/docs/reference/ekscluster#specdistributionmodulesingress
+[schema-reference-kfd]: https://docs.sighup.io/docs/reference/kfddistribution#specdistributionmodulesingress
+[schema-reference-onprem]: https://docs.sighup.io/docs/reference/onpremises#specdistributionmodulesingress
 
 <!-- </SD-DOCS> -->
+
+## License
+
+For license details please see [LICENSE](../../LICENSE)

--- a/katalog/haproxy/README.md
+++ b/katalog/haproxy/README.md
@@ -2,122 +2,27 @@
 
 <!-- <SD-DOCS> -->
 
-[HAProxy Ingress Controller][haproxy-page] is an Ingress Controller for [HAProxy][haproxy-main] load balancer, it manages HAProxy in a Kubernetes native manner. This package supports both single and dual (internal/external) deployment modes.
+## Overview
 
-## Requirements
+HAProxy Ingress Controller is an Ingress Controller for the [HAProxy][haproxy-main] load balancer, managing HAProxy in a Kubernetes native manner. This package supports both single and dual (internal/external) deployment modes. The default configuration enables SSL redirect with status code `301`, deploys as a `DaemonSet`, exposes metrics via a ServiceMonitor, includes a Grafana dashboard, and uses a TLS default certificate managed by cert-manager.
 
-- Kubernetes >= `1.31.0`
-- Kustomize >= `v5.6.0`
-- `cert-manager`
+## Upstream project
 
-## Image repository and tag
-
-- HAProxy Ingress Controller image: `registry.sighup.io/fury/haproxytech/kubernetes-ingress:3.2.8`
-- HAProxy Ingress Controller repo: [https://github.com/haproxytech/kubernetes-ingress](https://github.com/haproxytech/kubernetes-ingress)
-
-## Configuration
-
-HAProxy Ingress Controller is deployed with the following default configuration:
-
-- SSL redirect enabled with status code `301`
-- Deployed as a `DaemonSet`
-- Metrics exposed via ServiceMonitor
-- Grafana dashboard included
-- TLS default certificate managed by cert-manager
+This package is based on the upstream [HAProxy Ingress Controller][haproxy-github].
 
 ## Deployment
 
-> You'll need to have deployed [`cert-manager`](../cert-manager/) first, the TLS default certificate requires cert-manager issuers.
+This package is deployed as part of **Ingress Module** when you create a cluster with `furyctl`.
 
-### Single deployment
-
-Deploys a single HAProxy Ingress Controller with IngressClass `haproxy`.
-
-```bash
-kustomize build katalog/haproxy/single | kubectl apply -f -
-```
-
-### Dual deployment
-
-Deploys two HAProxy Ingress Controllers:
-- **External** controller with IngressClass `haproxy-external` for public traffic
-- **Internal** controller with IngressClass `haproxy-internal` for private traffic
-
-```bash
-kustomize build katalog/haproxy/dual | kubectl apply -f -
-```
-
-## Common customizations
-
-Both single and dual packages are deployed as `DaemonSet`, meaning they will deploy 1 ingress-controller pod on every worker node.
-
-If your cluster has `infra` nodes, you should patch the DaemonSet adding the `NodeSelector` for the `infra` nodes. You can do this using the following kustomize patch:
-
-**Single:**
-
-```yaml
----
-apiVersion: apps/v1
-kind: DaemonSet
-metadata:
-  name: haproxy-ingress
-spec:
-  template:
-    spec:
-      nodeSelector:
-        node-kind.sighup.io/infra: ""
-```
-
-**Dual:**
-
-```yaml
----
-apiVersion: apps/v1
-kind: DaemonSet
-metadata:
-  name: haproxy-ingress-external
-spec:
-  template:
-    spec:
-      nodeSelector:
-        node-kind.sighup.io/infra: ""
----
-apiVersion: apps/v1
-kind: DaemonSet
-metadata:
-  name: haproxy-ingress-internal
-spec:
-  template:
-    spec:
-      nodeSelector:
-        node-kind.sighup.io/infra: ""
-```
-
-## Alerts
-
-The following Prometheus [alerts][prometheus-alerts] are defined for this package.
-
-### HAProxy Ingress Controller Alert Rules
-
-| Parameter                                | Description                                                                                                           | Severity | Interval |
-| ---------------------------------------- | --------------------------------------------------------------------------------------------------------------------- | -------- | :------: |
-| `HaproxyIngressTargetDown`               | This alert fires if Prometheus target discovery was not able to reach haproxy-ingress metrics in the last 15 minutes. | critical |   15m    |
-| `HaproxyHighHttp4xxErrorRateBackend`     | This alert fires if the 4xx error rate measured on a 2 minute window exceeds 10% for 5 minutes.                       | warning  |    5m    |
-| `HaproxyHighHttp5xxErrorRateBackend`     | This alert fires if the 5xx error rate measured on a 2 minute window exceeds 10% for 10 minutes.                      | critical |   10m    |
-| `HaproxyServerResponseErrors`            | This alert fires if a specific backend server has response error rate exceeding 5% for 5 minutes.                     | warning  |    5m    |
-| `HaproxyBackendConnectionErrors`         | This alert fires if connection errors exceed 100 per second for 5 minutes on a backend.                               | warning  |    5m    |
-| `HaproxyBackendNoAliveServers`           | This alert fires immediately when a backend has no healthy servers available.                                         | critical |    0m    |
-| `HaproxyBackendPendingRequests`          | This alert fires if requests have been queued for a backend for more than 5 minutes.                                  | warning  |    5m    |
-| `HaproxyFrontendSecurityBlockedRequests` | This alert fires if more than 10 connections per second are being denied on a frontend for 2 minutes.                 | warning  |    2m    |
-| `HaproxyBackendLatencyHigh`              | This alert fires if average backend response time exceeds 5 seconds for 10 minutes.                                   | warning  |   10m    |
-| `HaproxyBackendLatencyCritical`          | This alert fires if average total time exceeds 10 seconds for 10 minutes.                                             | critical |   10m    |
-| `HaproxyServerHealthcheckFailure`        | This alert fires if health check failures are detected for a server over a 5 minute period.                           | warning  |    5m    |
-| `HaproxyIngressConfigSyncFailed`         | This alert fires if the ingress configuration sync failed in the last 10 minutes.                                     | warning  |   10m    |
+You can customize it under `spec.distribution.modules.ingress.haproxy` in your `furyctl.yaml`. See the [module documentation](../../README.md) and the configuration reference ([EKSCluster][schema-reference-eks], [KFDDistribution][schema-reference-kfd], [OnPremises][schema-reference-onprem]) for the available options.
 
 <!-- Links -->
-[haproxy-page]: https://github.com/haproxytech/kubernetes-ingress
+
 [haproxy-main]: https://www.haproxy.org
-[prometheus-alerts]: https://prometheus.io/docs/prometheus/latest/configuration/alerting_rules/
+[haproxy-github]: https://github.com/haproxytech/kubernetes-ingress
+[schema-reference-eks]: https://docs.sighup.io/docs/reference/ekscluster#specdistributionmodulesingress
+[schema-reference-kfd]: https://docs.sighup.io/docs/reference/kfddistribution#specdistributionmodulesingress
+[schema-reference-onprem]: https://docs.sighup.io/docs/reference/onpremises#specdistributionmodulesingress
 
 <!-- </SD-DOCS> -->
 

--- a/katalog/haproxy/README.md
+++ b/katalog/haproxy/README.md
@@ -4,7 +4,7 @@
 
 ## Overview
 
-HAProxy Ingress Controller is an Ingress Controller for the [HAProxy][haproxy-main] load balancer, managing HAProxy in a Kubernetes native manner. This package supports both single and dual (internal/external) deployment modes. The default configuration enables SSL redirect with status code `301`, deploys as a `DaemonSet`, exposes metrics via a ServiceMonitor, includes a Grafana dashboard, and uses a TLS default certificate managed by cert-manager.
+HAProxy Kubernetes Ingress Controller is an Ingress Controller for the [HAProxy][haproxy-main] load balancer, managing HAProxy in a Kubernetes native manner. This package supports both single and dual (internal/external) deployment modes. The default configuration enables SSL redirect with status code `301`, deploys as a `DaemonSet`, exposes metrics via a ServiceMonitor, includes a Grafana dashboard, and uses a TLS default certificate managed by cert-manager.
 
 ## Upstream project
 

--- a/katalog/haproxy/README.md
+++ b/katalog/haproxy/README.md
@@ -8,7 +8,7 @@ HAProxy Kubernetes Ingress Controller is an Ingress Controller for the [HAProxy]
 
 ## Upstream project
 
-This package is based on the upstream [HAProxy Ingress Controller][haproxy-github].
+This package is based on the upstream [HAProxy Kubernetes Ingress Controller][haproxy-github].
 
 ## Deployment
 

--- a/katalog/nginx/README.md
+++ b/katalog/nginx/README.md
@@ -2,108 +2,28 @@
 
 <!-- <SD-DOCS> -->
 
-Ingress NGINX is an Ingress Controller for [NGINX][nginx-page] web server and reverse-proxy, it manages NGINX in a Kubernetes native manner. This package deploys Ingress Controller for clusters created with `kubeadm`.
+## Overview
 
-## Requirements
+Ingress NGINX is an Ingress Controller for the [NGINX][nginx-page] web server and reverse proxy, managing NGINX in a Kubernetes native manner. This package deploys a single NGINX controller that serves all traffic. The default configuration sets a maximum client request body size of `10m`, a `301` redirect status code, Prometheus metrics scraping, and a validating admission webhook for ingress definitions.
 
-- Kubernetes >= `1.30.0`
-- Kustomize >= `v5.6.0`
-- `cert-manager`
+## Upstream project
 
-## Image repository and tag
-
-- Ingress NGINX image: `registry.sighup.io/fury/ingress-nginx/controller:v1.15.5-chainguard` (built in-house from the Chainguard-maintained fork)
-- Ingress NGINX upstream repo (archived): [https://github.com/kubernetes/ingress-nginx](https://github.com/kubernetes/ingress-nginx)
-- Ingress NGINX fork repo (maintained): [https://github.com/chainguard-forks/ingress-nginx](https://github.com/chainguard-forks/ingress-nginx)
-
-## Configuration
-
-Ingress NGINX single is deployed with the following default configuration:
-
-- Maximum allowed size of the client request body: `10m`
-- HTTP status code used in redirects: `301`
-- Metrics are scraped by Prometheus every `10s`
-- Validating Admission webhook that validates an ingress definition does not break NGINX configuration.
+This package is based on the upstream [Ingress NGINX][nginx-github]. SIGHUP rebuilds the controller on top of [Chainguard][chainguard] hardened, minimal container images (hence the `-chainguard` image tags), so the deployed images are not the upstream ones.
 
 ## Deployment
 
-> ⚠️ You'll need to have deployed [`cert-manager`](../cert-manager/) first, the validating webhook needs to have TLS communication with the API server.
+This package is deployed as part of **Ingress Module** when you create a cluster with `furyctl`.
 
-1. Add the module to your `Furyfile.yml`:
-
-```yaml
-bases:
-  - name: ingress/nginx
-    version: "v5.0.0"
-```
-
-> See `furyctl` [documentation][furyctl-repo] for additional details about `Furyfile.yml` format.
-
-2. Execute `furyctl vendor -H` to download the packages
-
-3. Inspect the download packages under `./vendor/katalog/ingress/dual-nginx`.
-
-4. Define a `kustomization.yaml` that includes the `./vendor/katalog/ingress/nginx` directory as resource.
-
-```yaml
-resources:
-  - ./vendor/katalog/ingress/nginx
-```
-
-5. Apply the necessary patches. You can find a list of common customization [here](#common-customizations).
-
-6. To deploy the packages to your cluster, execute:
-
-```bash
-kustomize build . | kubectl apply -f -
-```
-
-You are now ready to expose your applications using Kubernetes `Ingress` objects.
-
-## Common customizations
-
-`nginx` package is deployed by default as a `DaemonSet`, meaning that it will deploy 1 ingress-controller pod on every worker node.
-
-This is probably NOT what you want, standard Fury clusters have at least 1 `infra` node (nodes that are dedicated to Fury infrastructural components, like Prometheus, OpenSearch, and the Ingress Controllers).
-
-If your cluster has `infra` nodes you should patch the DaemonSet adding the `NodeSelector` for the `infra` nodes to the Ingress `DaemonSet`. You can do this using the following kustomize patch:
-
-```yaml
----
-apiVersion: apps/v1
-kind: DaemonSet
-metadata:
-  name: ingress-nginx-controller
-spec:
-  template:
-    spec:
-      nodeSelector:
-        node-kind.sighup.io/infra: ""
-```
-
-If you don't have infra nodes and you don't want to run ingress controllers on all your worker nodes, you should probably label some nodes and adjust the previous `NodeSelector` accordingly.
-
-## Alerts
-
-Followings Prometheus [alerts][prometheus-alerts] are already defined for this package.
-
-### NGINX Ingress Controller Alert Rules
-
-| Parameter                           | Description                                                                                                                                         | Severity | Interval |
-| ----------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------- | -------- | :------: |
-| `NginxIngressDown`                  | This alert fires if Prometheus target discovery was not able to reach ingress-nginx-metrics in the last 15 minutes.                                 | critical |   15m    |
-| `NginxIngressFailureRate`           | This alert fires if the failure rate (the rate of 5xx responses) measured on a time window of 2 minutes was higher than 10% in the last 10 minutes. | critical |   10m    |
-| `NginxIngressFailedReload`          | This alert fires if the ingress' configuration reload failed in the last 10 minutes.                                                                | warning  |   10m    |
-| `NginxIngressLatencyTooHigh`        | This alert fires if the ingress 99th percentile latency was more than 5 seconds in the last 10 minutes.                                             | warning  |   10m    |
-| `NginxIngressLatencyTooHigh`        | This alert fires if the ingress 99th percentile latency was more than 10 seconds in the last 10 minutes.                                            | critical |   10m    |
-| `NginxIngressCertificateExpiration` | This alert fires if the certificate for a given host is expiring in less than 7 days.                                                               | warning  |          |
-| `NginxIngressCertificateExpiration` | This alert fires if the certificate for a given host is expiring in less than 1 day.                                                                | critical |          |
+You can customize it under `spec.distribution.modules.ingress.nginx` in your `furyctl.yaml`. See the [module documentation](../../README.md) and the configuration reference ([EKSCluster][schema-reference-eks], [KFDDistribution][schema-reference-kfd], [OnPremises][schema-reference-onprem]) for the available options.
 
 <!-- Links -->
 
-[furyctl-repo]: https://github.com/sighupio/furyctl
 [nginx-page]: https://nginx.org
-[prometheus-alerts]: https://prometheus.io/docs/prometheus/latest/configuration/alerting_rules/
+[nginx-github]: https://github.com/kubernetes/ingress-nginx
+[chainguard]: https://www.chainguard.dev
+[schema-reference-eks]: https://docs.sighup.io/docs/reference/ekscluster#specdistributionmodulesingress
+[schema-reference-kfd]: https://docs.sighup.io/docs/reference/kfddistribution#specdistributionmodulesingress
+[schema-reference-onprem]: https://docs.sighup.io/docs/reference/onpremises#specdistributionmodulesingress
 
 <!-- </SD-DOCS> -->
 

--- a/modules/aws-cert-manager/README.md
+++ b/modules/aws-cert-manager/README.md
@@ -4,7 +4,8 @@
 
 > **Note**: This module is part of [SIGHUP Distribution (SD)](https://github.com/sighupio/distribution) and is consumed automatically by `furyctl` when you create a cluster. You don't need to use it directly: its inputs are derived from your `furyctl.yaml`. The reference below is intended for maintainers and contributors.
 
-> ⚠️ **Warning**: this module uses ["IAM Roles for ServiceAccount"](https://docs.aws.amazon.com/eks/latest/userguide/iam-roles-for-service-accounts.html) to inject AWS credentials inside cert-manager pods
+> [!WARNING]
+> This module uses ["IAM Roles for ServiceAccount"](https://docs.aws.amazon.com/eks/latest/userguide/iam-roles-for-service-accounts.html) to inject AWS credentials inside cert-manager pods
 
 ## Requirements
 

--- a/modules/aws-cert-manager/README.md
+++ b/modules/aws-cert-manager/README.md
@@ -1,8 +1,10 @@
 # IAM for AWS cert-manager
 
-This Terraform module provides an easy way to generate cert-manager required IAM permissions.
+**This Terraform module generates the IAM permissions required by cert-manager on AWS.**
 
-> ⚠️ **Warning**: this module uses ["IAM Roles for ServiceAccount"](https://docs.aws.amazon.com/eks/latest/userguide/iam-roles-for-service-accounts.html) to inject AWS credentials inside cluster autoscaler pods
+> **Note**: This module is part of [SIGHUP Distribution (SD)](https://github.com/sighupio/distribution) and is consumed automatically by `furyctl` when you create a cluster. You don't need to use it directly: its inputs are derived from your `furyctl.yaml`. The reference below is intended for maintainers and contributors.
+
+> ⚠️ **Warning**: this module uses ["IAM Roles for ServiceAccount"](https://docs.aws.amazon.com/eks/latest/userguide/iam-roles-for-service-accounts.html) to inject AWS credentials inside cert-manager pods
 
 ## Requirements
 
@@ -44,14 +46,3 @@ This Terraform module provides an easy way to generate cert-manager required IAM
 | ----------------------------- | ----------------------------------------- |
 | cert\_manager\_iam\_role\_arn | cert-manager IAM role                     |
 | cert\_manager\_patches        | cert-manager Kubernetes resources patches |
-
-## Usage
-
-```hcl
-module "cert_manager_iam_role" {
-  source             = "../vendor/modules/ingress/aws-cert-manager"
-  cluster_name       = "myekscluster"
-  public_zone_id     = "Z1BM4RA99PG48O"
-  tags               = {"mykey": "myvalue"}
-}
-```

--- a/modules/aws-external-dns/README.md
+++ b/modules/aws-external-dns/README.md
@@ -5,7 +5,8 @@
 > [!NOTE]
 > This module is part of [SIGHUP Distribution (SD)](https://github.com/sighupio/distribution) and is consumed automatically by `furyctl` when you create a cluster. You don't need to use it directly: its inputs are derived from your `furyctl.yaml`. The reference below is intended for maintainers and contributors.
 
-> ⚠️ **Warning**: this module uses ["IAM Roles for ServiceAccount"](https://docs.aws.amazon.com/eks/latest/userguide/iam-roles-for-service-accounts.html) to inject AWS credentials inside external-dns pods.
+> [!WARNING]
+> This module uses ["IAM Roles for ServiceAccount"](https://docs.aws.amazon.com/eks/latest/userguide/iam-roles-for-service-accounts.html) to inject AWS credentials inside external-dns pods.
 
 ## Requirements
 

--- a/modules/aws-external-dns/README.md
+++ b/modules/aws-external-dns/README.md
@@ -2,7 +2,8 @@
 
 **This Terraform module generates the IAM permissions required by external-dns (public and private) on AWS.**
 
-> **Note**: This module is part of [SIGHUP Distribution (SD)](https://github.com/sighupio/distribution) and is consumed automatically by `furyctl` when you create a cluster. You don't need to use it directly: its inputs are derived from your `furyctl.yaml`. The reference below is intended for maintainers and contributors.
+> [!NOTE]
+> This module is part of [SIGHUP Distribution (SD)](https://github.com/sighupio/distribution) and is consumed automatically by `furyctl` when you create a cluster. You don't need to use it directly: its inputs are derived from your `furyctl.yaml`. The reference below is intended for maintainers and contributors.
 
 > ⚠️ **Warning**: this module uses ["IAM Roles for ServiceAccount"](https://docs.aws.amazon.com/eks/latest/userguide/iam-roles-for-service-accounts.html) to inject AWS credentials inside external-dns pods.
 

--- a/modules/aws-external-dns/README.md
+++ b/modules/aws-external-dns/README.md
@@ -1,8 +1,10 @@
 # IAM for AWS external-dns
 
-This terraform module provides an easy way to generate external-dns (public and private) required IAM permissions.
+**This Terraform module generates the IAM permissions required by external-dns (public and private) on AWS.**
 
-> ⚠️ **Warning**: this module uses ["IAM Roles for ServiceAccount"](https://docs.aws.amazon.com/eks/latest/userguide/iam-roles-for-service-accounts.html) to inject AWS credentials inside cluster autoscaler pods.
+> **Note**: This module is part of [SIGHUP Distribution (SD)](https://github.com/sighupio/distribution) and is consumed automatically by `furyctl` when you create a cluster. You don't need to use it directly: its inputs are derived from your `furyctl.yaml`. The reference below is intended for maintainers and contributors.
+
+> ⚠️ **Warning**: this module uses ["IAM Roles for ServiceAccount"](https://docs.aws.amazon.com/eks/latest/userguide/iam-roles-for-service-accounts.html) to inject AWS credentials inside external-dns pods.
 
 ## Requirements
 
@@ -50,16 +52,3 @@ This terraform module provides an easy way to generate external-dns (public and 
 | external\_dns\_private\_patches        | external-dns-private Kubernetes resources patches |
 | external\_dns\_public\_iam\_role\_arn  | external-dns-public IAM role                      |
 | external\_dns\_public\_patches         | external-dns-public Kubernetes resources patches  |
-
-## Usage
-
-```hcl
-module "external_dns_iam_role" {
-  source             = "../vendor/modules/ingress/aws-external-dns"
-  cluster_name       = "myekscluster"
-  public_zone_id     = "Z1BM4RA99PG48O"
-  private_zone_id    = "Z1BM4RA99PG499"
-  enable_private     = true
-  tags               = {"mykey": "myvalue"}
-}
-```


### PR DESCRIPTION
### Summary 💡

This PR replicates the documentation refactor defined in `module-aws` (#104) on this module: the docs are now furyctl/SD-centric and the legacy `Furyfile.yml` + `furyctl legacy vendor` + `kustomize build | kubectl apply` workflow has been removed.

The motivation: this documentation ends up on docs.sighup.io but still described the old legacy workflow and exposed internal implementation details (kustomize patches, raw manifests, image coordinates) that don't make sense on a public docs site.

Relates: sighupio/module-aws#104

### Description 📝

- **`README.md` (SD-DOCS block)**: removed the legacy `Usage`/`Prerequisites`/manual-deployment sections (controller choice, default config, cert-manager/forecastle manual steps). New `Usage` section explains the module is deployed automatically as part of SD by `furyctl`, with optional `furyctl.yaml` (`spec.distribution.modules.ingress`) examples for **both** NGINX and HAProxy as ingress controllers, plus links to the configuration schema reference (EKSCluster / KFDDistribution / OnPremises).
- **`katalog/*/README.md`**: rewritten to the shared template (Overview → Upstream project → Deployment → License). Removed kustomize/`kubectl apply` instructions, raw manifests and image coordinates.
  - **nginx / dual-nginx**: clarified in "Upstream project" that the controller is rebuilt by SIGHUP on top of Chainguard hardened images (the `-chainguard` tags), so the deployed images are not the upstream ones.
  - **external-dns**: clarified that it is managed internally and has no dedicated `furyctl.yaml` options (its DNS providers/credentials are derived from the cluster config and provisioned by the distribution).
- **`modules/*/README.md`** (Terraform): added the SD-managed note, dropped the standalone usage/instantiation examples, kept the terraform-docs Requirements/Providers/Inputs/Outputs tables.

### Breaking Changes 💔

None, documentation only.

### Tests performed 🧪

- [x] No `Furyfile` / `furyctl legacy vendor` / `kustomize build | kubectl apply` references left inside the `SD-DOCS` blocks
- [x] `SD-DOCS` / `FOOTER` markers intact, no orphan reference links
- [x] `furyctl.yaml` snippet fields and enum values match the v1alpha2 schema (`nginx`/`haproxy` `type`, `tls.provider`, `certManager.clusterIssuer.type`)
- [ ] Visual review of the GitHub markdown rendering

### Future work 🔧

- Replicate the same template on the remaining modules.